### PR TITLE
refactor: improve attribute handling in SchemaCanvas and ReferenceAtt…

### DIFF
--- a/frontend/src/components/schema/ReferenceAttribute.tsx
+++ b/frontend/src/components/schema/ReferenceAttribute.tsx
@@ -15,7 +15,7 @@ const getOptions = (accounts: Account[]) => {
   
   list.push(<Item key="">{Translations.NoneOption[DEFAULT_LANGUAGE]}</Item>);
 
-  accounts?.sort((a, b) => a.name.localeCompare(b.name)).map((account) => {
+  accounts?.slice().sort((a, b) => a.name.localeCompare(b.name)).map((account) => {
     list.push(<Item key={account._id}>{account.name}</Item>);
   });
 

--- a/frontend/src/components/schema/SchemaCanvas.tsx
+++ b/frontend/src/components/schema/SchemaCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { SchemaAttribute, Schema, SchemaSelectAttribute } from '../../interfaces/Schema';
 import { SelectAttribute } from './SelectAttribute';
 import { TextAreaAttribute } from './TextAreaAttribute';
@@ -58,6 +58,8 @@ export const SchemaCanvas = ({
   };
 
   const getAttribute = (attribute: SchemaAttribute, value: string | number | boolean | null) => {
+    const { key: _key, ...attributeProps } = attribute;
+
     switch (attribute.type) {
       case 'text':
         return (
@@ -66,7 +68,7 @@ export const SchemaCanvas = ({
             attributeKey={attribute.key}
             value={toStringOrNull(value)}
             isDisabled={isDisabled}
-            {...attribute}
+            {...attributeProps}
           />
         );
       case 'email':
@@ -76,7 +78,7 @@ export const SchemaCanvas = ({
             attributeKey={attribute.key}
             value={toStringOrNull(value)}
             isDisabled={isDisabled}
-            {...attribute}
+            {...attributeProps}
           />
         );
       case 'link':
@@ -86,7 +88,7 @@ export const SchemaCanvas = ({
             attributeKey={attribute.key}
             value={toStringOrNull(value)}
             isDisabled={isDisabled}
-            {...attribute}
+            {...attributeProps}
           />
         );
       case 'textarea':
@@ -96,7 +98,7 @@ export const SchemaCanvas = ({
             attributeKey={attribute.key}
             value={toStringOrNull(value)}
             isDisabled={isDisabled}
-            {...attribute}
+            {...attributeProps}
           />
         );
       case 'select':
@@ -105,7 +107,7 @@ export const SchemaCanvas = ({
             update={updateAttribute}
             attributeKey={attribute.key}
             value={toStringOrNull(value)}
-            {...(attribute as SchemaSelectAttribute)}
+            {...(attributeProps as Omit<SchemaSelectAttribute, 'key'>)}
             isDisabled={isDisabled}
           />
         );
@@ -115,7 +117,7 @@ export const SchemaCanvas = ({
             update={updateAttribute}
             attributeKey={attribute.key}
             value={toStringOrNull(value)}
-            {...attribute}
+            {...attributeProps}
             isDisabled={isDisabled}
           />
         );
@@ -125,7 +127,7 @@ export const SchemaCanvas = ({
             update={updateAttribute}
             attributeKey={attribute.key}
             value={toBooleanOrNull(value)}
-            {...attribute}
+            {...attributeProps}
             isDisabled={isDisabled}
           />
         );
@@ -135,7 +137,11 @@ export const SchemaCanvas = ({
   return (
     <>
       {schema?.attributes?.map((attribute) => {
-        return getAttribute(attribute!, values?.[attribute.key] ?? null);
+        return (
+          <Fragment key={attribute.key}>
+            {getAttribute(attribute!, values?.[attribute.key] ?? null)}
+          </Fragment>
+        );
       })}
     </>
   );

--- a/frontend/src/components/setup/schema/SchemaCanvas.tsx
+++ b/frontend/src/components/setup/schema/SchemaCanvas.tsx
@@ -1,5 +1,5 @@
 import {Button, Item, Picker} from '@adobe/react-spectrum';
-import {Key, useEffect, useState} from 'react';
+import {Fragment, Key, useEffect, useState} from 'react';
 import {DragDropContext, Droppable, DropResult} from 'react-beautiful-dnd';
 import {ANIMALS, DEFAULT_LANGUAGE} from '../../../Constants';
 import {generateUUID} from '../../../helpers/Helper';
@@ -140,16 +140,18 @@ export const SchemaCanvas = ({schema: schemaImported, validate}: SchemaCanvasPro
     };
 
     const getAttribute = (item: SchemaAttribute) => {
+        const {key: _key, ...itemProps} = item;
+
         switch (item.type) {
             case SchemaAttributeType.Text:
-                return <TextAttribute update={update} remove={remove} attributeKey={item.key} {...item} />;
+                return <TextAttribute update={update} remove={remove} attributeKey={item.key} {...itemProps} />;
             case SchemaAttributeType.Email:
-                return <EmailAttribute update={update} remove={remove} attributeKey={item.key} {...item} />;
+                return <EmailAttribute update={update} remove={remove} attributeKey={item.key} {...itemProps} />;
             case SchemaAttributeType.Link:
-                return <LinkAttribute update={update} remove={remove} attributeKey={item.key} {...item} />;
+                return <LinkAttribute update={update} remove={remove} attributeKey={item.key} {...itemProps} />;
             case SchemaAttributeType.TextArea:
                 return (
-                    <TextAreaAttribute update={update} remove={remove} attributeKey={item.key} {...item} />
+                    <TextAreaAttribute update={update} remove={remove} attributeKey={item.key} {...itemProps} />
                 );
             case SchemaAttributeType.Select:
                 return (
@@ -157,7 +159,7 @@ export const SchemaCanvas = ({schema: schemaImported, validate}: SchemaCanvasPro
                         update={update}
                         remove={remove}
                         attributeKey={item.key}
-                        {...(item as SchemaSelectAttribute)}
+                        {...(itemProps as Omit<SchemaSelectAttribute, 'key'>)}
                     />
                 );
             case SchemaAttributeType.Reference:
@@ -166,12 +168,12 @@ export const SchemaCanvas = ({schema: schemaImported, validate}: SchemaCanvasPro
                         update={update}
                         remove={remove}
                         attributeKey={item.key}
-                        {...(item as SchemaReferenceAttribute)}
+                        {...(itemProps as Omit<SchemaReferenceAttribute, 'key'>)}
                     />
                 );
             case SchemaAttributeType.Boolean:
                 return (
-                    <BooleanAttribute update={update} remove={remove} attributeKey={item.key} {...item} />
+                    <BooleanAttribute update={update} remove={remove} attributeKey={item.key} {...itemProps} />
                 );
             default:
                 return <div>{Translations.UnknownAttributeTypeError[DEFAULT_LANGUAGE]}</div>; // TODO should throw
@@ -186,7 +188,7 @@ export const SchemaCanvas = ({schema: schemaImported, validate}: SchemaCanvasPro
                         return (
                             <div ref={provided.innerRef} {...provided.droppableProps}>
                                 {items.map((item) => {
-                                    return getAttribute(item);
+                                    return <Fragment key={item.key}>{getAttribute(item)}</Fragment>;
                                 })}
 
                                 {provided.placeholder}


### PR DESCRIPTION
…ribute components

- Updated SchemaCanvas to destructure item properties, omitting the 'key' attribute for better clarity and maintainability.
- Enhanced ReferenceAttribute to use slice before sorting accounts, ensuring the original array remains unmodified.