### PR TITLE
[codex] Export opportunity sheet as PDF

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-dom": "^18.2.18",
         "@types/redux-logger": "^3.0.12",
         "framer-motion": "^12.19.2",
+        "jspdf": "^4.2.1",
         "luxon": "^3.4.4",
         "next-themes": "^0.4.6",
         "react": "^18.2.0",
@@ -6103,6 +6104,12 @@
       "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -6114,6 +6121,13 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -6187,6 +6201,13 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -7247,6 +7268,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -7381,6 +7412,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -7482,6 +7533,18 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -7514,6 +7577,16 @@
       "license": "MIT",
       "dependencies": {
         "tiny-invariant": "^1.0.6"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -7810,6 +7883,16 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -8033,6 +8116,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8066,6 +8160,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/find-root": {
       "version": "1.1.0",
@@ -8301,6 +8401,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/immer": {
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
@@ -8370,6 +8484,12 @@
         "@formatjs/icu-messageformat-parser": "2.11.4",
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -8772,6 +8892,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9010,6 +9147,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9060,6 +9203,13 @@
       "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.3.tgz",
       "integrity": "sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA==",
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9180,6 +9330,16 @@
       "license": "MIT",
       "dependencies": {
         "proxy-compare": "^3.0.0"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/raf-schd": {
@@ -9631,6 +9791,13 @@
         "redux": "^4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -9693,6 +9860,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -9910,6 +10087,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -9987,11 +10174,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -10100,6 +10307,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/victory-vendor": {
@@ -10255,20 +10472,6 @@
         }
       }
     },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/web-vitals": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
@@ -10345,22 +10548,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@types/react-dom": "^18.2.18",
     "@types/redux-logger": "^3.0.12",
     "framer-motion": "^12.19.2",
+    "jspdf": "^4.2.1",
     "luxon": "^3.4.4",
     "next-themes": "^0.4.6",
     "react": "^18.2.0",

--- a/frontend/src/Translations.ts
+++ b/frontend/src/Translations.ts
@@ -182,6 +182,11 @@ export const Translations = {
         fr: 'Assigner',
     },
 
+    DownloadOpportunitySheetButton: {
+        en: 'Download PDF sheet',
+        fr: 'Télécharger la fiche PDF',
+    },
+
     // Filter buttons
     RecentlyUpdatedFilter: {
         en: 'Recently Updated',
@@ -264,6 +269,56 @@ export const Translations = {
     ExpectedCloseDateLabel: {
         en: 'Expected Close Date',
         fr: 'Date de clôture prévue',
+    },
+
+    StageLabel: {
+        en: 'Stage',
+        fr: 'Étape',
+    },
+
+    OpportunitySheetTitle: {
+        en: 'Opportunity sheet',
+        fr: 'Fiche opportunité',
+    },
+
+    OpportunitySheetSummaryTitle: {
+        en: 'Summary',
+        fr: 'Synthèse',
+    },
+
+    OpportunitySheetDetailsTitle: {
+        en: 'Sheet information',
+        fr: 'Informations de la fiche',
+    },
+
+    OpportunitySheetGeneratedAt: {
+        en: 'Export generated on',
+        fr: 'Export généré le',
+    },
+
+    OpportunitySheetContactsNameOnly: {
+        en: 'Referenced contacts are exported by name only.',
+        fr: 'Les contacts référencés sont exportés par nom uniquement.',
+    },
+
+    OpportunitySheetNoData: {
+        en: 'No data provided.',
+        fr: 'Aucune donnée renseignée.',
+    },
+
+    OpportunitySheetContactNotFound: {
+        en: 'Contact not found',
+        fr: 'Contact introuvable',
+    },
+
+    YesLabel: {
+        en: 'Yes',
+        fr: 'Oui',
+    },
+
+    NoLabel: {
+        en: 'No',
+        fr: 'Non',
     },
 
     // Messages

--- a/frontend/src/components/card/Layer.tsx
+++ b/frontend/src/components/card/Layer.tsx
@@ -13,15 +13,23 @@ import {
 } from '../../actions/Actions';
 import {
     selectActiveUsers,
+    selectAccounts,
     selectCard,
+    selectCurrency,
+    selectCustomOpportunityAmountLabel,
     selectInterfaceStateId, selectLane,
     selectLanes,
-    selectToken, selectUserId,
+    selectSchemaByType,
+    selectTeam,
+    selectToken,
+    selectUser,
+    selectUserId,
     store,
 } from '../../store/Store';
 import {Form} from './Form';
 import {Events} from './Events';
 import {Card, CardFormPreview, CardPreview} from '../../interfaces/Card';
+import {SchemaType} from '../../interfaces/Schema';
 import {useEffect, useMemo, useState} from 'react';
 import {ApplicationStore} from '../../store/ApplicationStore';
 import {Avatar} from '../Avatar';
@@ -32,6 +40,7 @@ import useMobileLayout from '../../hooks/useMobileLayout';
 import {getRequestClient} from '../../helpers/RequestHelper';
 import {IconLock} from "./IconLock";
 import {getErrorMessage} from '../../helpers/ErrorHelper';
+import {downloadOpportunitySheet} from '../../helpers/OpportunitySheetExportHelper';
 
 export const Layer = () => {
     const token = useSelector(selectToken);
@@ -40,6 +49,15 @@ export const Layer = () => {
 
     const id = useSelector(selectInterfaceStateId);
     const card = useSelector((store: ApplicationStore) => selectCard(store, id));
+    const lane = useSelector((store: ApplicationStore) => selectLane(store, card?.laneId));
+    const accounts = useSelector(selectAccounts);
+    const currency = useSelector(selectCurrency);
+    const customAmountLabel = useSelector(selectCustomOpportunityAmountLabel);
+    const team = useSelector(selectTeam);
+    const schema = useSelector((store: ApplicationStore) =>
+        selectSchemaByType(store, SchemaType.Card)
+    );
+    const owner = useSelector((store: ApplicationStore) => selectUser(store, card?.userId));
     const [isUserLayerVisible, setIsUserLayerVisible] = useState(false);
     const users = useSelector(selectActiveUsers);
     const lanes = useSelector(selectLanes);
@@ -105,6 +123,23 @@ export const Layer = () => {
         update(id, {...preview, amount: parseInt(preview.amount, 10)});
     };
 
+    const downloadSheet = () => {
+        if (!card) {
+            return;
+        }
+
+        void downloadOpportunitySheet({
+            card,
+            schema,
+            accounts,
+            lane,
+            owner,
+            team,
+            amountLabel: customAmountLabel || Translations.OpportunityAmount[DEFAULT_LANGUAGE],
+            currency,
+        });
+    };
+
     const handleDeleteCard = async () => {
         // Vérifier si l'utilisateur connecté est le propriétaire de la card
         if (card?.userId !== userId) {
@@ -119,7 +154,6 @@ export const Layer = () => {
         hideCardDetail();
     };
 
-    const lane = useSelector((store: ApplicationStore) => selectLane(store, card?.laneId));
     const [isDisabled, setIsDisabled] = useState<boolean>(false);
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
 
@@ -236,7 +270,15 @@ export const Layer = () => {
                     {/* Boutons sur la ligne d'en dessous */}
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
                         {/* Bouton Supprimer tout à gauche */}
-                        <div>
+                        <div style={{ display: 'flex', gap: '8px' }}>
+                            {id && card && (
+                                <Button
+                                    variant="secondary"
+                                    onPress={downloadSheet}
+                                >
+                                    {Translations.DownloadOpportunitySheetButton[DEFAULT_LANGUAGE]}
+                                </Button>
+                            )}
                             {id && (
                                 <Button 
                                     variant="secondary" 

--- a/frontend/src/helpers/OpportunitySheetExportHelper.ts
+++ b/frontend/src/helpers/OpportunitySheetExportHelper.ts
@@ -1,0 +1,336 @@
+import type { jsPDF as JsPdfDocument } from 'jspdf';
+import { Account } from '../interfaces/Account';
+import { Card } from '../interfaces/Card';
+import { Lane } from '../interfaces/Lane';
+import { Schema, SchemaAttribute, SchemaAttributeType } from '../interfaces/Schema';
+import { CurrencyCode, Team } from '../interfaces/Team';
+import { User } from '../interfaces/User';
+import { DEFAULT_CURRENCY, DEFAULT_LANGUAGE } from '../Constants';
+import { Translations } from '../Translations';
+import { getBrowserLocale } from './Helper';
+import { SchemaHelper } from './SchemaHelper';
+
+interface OpportunitySheetExportParams {
+  card: Card;
+  schema?: Schema;
+  accounts: Account[];
+  lane?: Lane;
+  owner?: User;
+  team?: Team;
+  amountLabel: string;
+  currency?: CurrencyCode;
+}
+
+interface ExportRow {
+  label: string;
+  value: string;
+}
+
+interface PdfLayout {
+  pageWidth: number;
+  pageHeight: number;
+  margin: number;
+  contentWidth: number;
+  footerY: number;
+  y: number;
+}
+
+const PDF_MARGIN = 18;
+const PDF_LINE_HEIGHT = 5;
+const PDF_LABEL_WIDTH = 58;
+const PDF_ROW_GAP = 6;
+const PDF_ROW_PADDING = 3;
+
+const normalizePdfText = (value: string): string => {
+  return value.replace(/\s+/g, ' ').trim();
+};
+
+const fileNamePart = (value: string): string => {
+  const normalized = value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return normalized || 'opportunite';
+};
+
+const formatDate = (value?: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(getBrowserLocale(), {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+};
+
+const formatDateTime = (value?: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(getBrowserLocale(), {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+};
+
+const formatAmount = (amount: number, currency?: CurrencyCode): string => {
+  if (currency === CurrencyCode.MT2) {
+    return `${amount.toLocaleString(getBrowserLocale(), {
+      style: 'unit',
+      unit: 'meter',
+      unitDisplay: 'narrow',
+    })}²`;
+  }
+
+  return amount.toLocaleString(getBrowserLocale(), {
+    style: 'currency',
+    currency: currency ?? DEFAULT_CURRENCY,
+  });
+};
+
+const formatBoolean = (value: boolean): string => {
+  return value
+    ? Translations.YesLabel[DEFAULT_LANGUAGE]
+    : Translations.NoLabel[DEFAULT_LANGUAGE];
+};
+
+const contactNameFor = (accounts: Account[], id: string): string => {
+  return (
+    accounts.find((account) => account._id === id)?.name
+    ?? Translations.OpportunitySheetContactNotFound[DEFAULT_LANGUAGE]
+  );
+};
+
+const formatAttributeValue = (
+  attribute: SchemaAttribute,
+  value: string | number | boolean | null | undefined,
+  accounts: Account[]
+): string => {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  if (SchemaHelper.isReferenceAttribute(attribute)) {
+    return contactNameFor(accounts, value.toString());
+  }
+
+  if (attribute.type === SchemaAttributeType.Boolean && typeof value === 'boolean') {
+    return formatBoolean(value);
+  }
+
+  return value.toString();
+};
+
+const buildAttributeRows = (card: Card, schema: Schema | undefined, accounts: Account[]) => {
+  if (!schema?.attributes) {
+    return [];
+  }
+
+  return schema.attributes
+    .slice()
+    .sort((left, right) => left.index - right.index)
+    .map((attribute) => ({
+      label: attribute.name,
+      value: formatAttributeValue(attribute, card.attributes?.[attribute.key], accounts),
+    }))
+    .filter((row) => row.value !== '');
+};
+
+const buildSummaryRows = ({
+  card,
+  lane,
+  owner,
+  amountLabel,
+  currency,
+}: OpportunitySheetExportParams): ExportRow[] => {
+  return [
+    { label: Translations.OpportunityNameLabel[DEFAULT_LANGUAGE], value: card.name },
+    { label: Translations.StageLabel[DEFAULT_LANGUAGE], value: lane?.name ?? '' },
+    { label: Translations.UserLabel[DEFAULT_LANGUAGE], value: owner?.name ?? '' },
+    { label: amountLabel, value: formatAmount(card.amount, currency) },
+    { label: Translations.NextFollowUpLabel[DEFAULT_LANGUAGE], value: formatDate(card.nextFollowUpAt) },
+    {
+      label: Translations.ExpectedCloseDateLabel[DEFAULT_LANGUAGE],
+      value: formatDate(card.closedAt),
+    },
+    { label: Translations.CreatedAtLabel[DEFAULT_LANGUAGE], value: formatDateTime(card.createdAt) },
+    { label: Translations.LastUpdateLabel[DEFAULT_LANGUAGE], value: formatDateTime(card.updatedAt) },
+  ].filter((row) => row.value !== '');
+};
+
+const splitText = (doc: JsPdfDocument, text: string, maxWidth: number): string[] => {
+  return doc.splitTextToSize(normalizePdfText(text), maxWidth) as string[];
+};
+
+const getLayout = (doc: JsPdfDocument): PdfLayout => {
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+
+  return {
+    pageWidth,
+    pageHeight,
+    margin: PDF_MARGIN,
+    contentWidth: pageWidth - PDF_MARGIN * 2,
+    footerY: pageHeight - PDF_MARGIN,
+    y: PDF_MARGIN,
+  };
+};
+
+const ensureSpace = (doc: JsPdfDocument, layout: PdfLayout, height: number): void => {
+  if (layout.y + height <= layout.footerY - 8) {
+    return;
+  }
+
+  doc.addPage();
+  layout.y = layout.margin;
+};
+
+const drawTitle = (doc: JsPdfDocument, layout: PdfLayout, params: OpportunitySheetExportParams): void => {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(20);
+  doc.setTextColor(29, 29, 27);
+  doc.text(Translations.OpportunitySheetTitle[DEFAULT_LANGUAGE], layout.margin, layout.y);
+  layout.y += 9;
+
+  if (params.team?.name) {
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(85, 85, 85);
+    doc.text(params.team.name, layout.margin, layout.y);
+    layout.y += 7;
+  }
+
+  doc.setDrawColor(29, 29, 27);
+  doc.setLineWidth(0.4);
+  doc.line(layout.margin, layout.y, layout.pageWidth - layout.margin, layout.y);
+  layout.y += 11;
+};
+
+const drawSectionTitle = (doc: JsPdfDocument, layout: PdfLayout, title: string): void => {
+  ensureSpace(doc, layout, 13);
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(13);
+  doc.setTextColor(29, 29, 27);
+  doc.text(title, layout.margin, layout.y);
+  layout.y += 7;
+};
+
+const drawEmptyState = (doc: JsPdfDocument, layout: PdfLayout): void => {
+  ensureSpace(doc, layout, 8);
+
+  doc.setFont('helvetica', 'italic');
+  doc.setFontSize(10);
+  doc.setTextColor(120, 120, 120);
+  doc.text(Translations.OpportunitySheetNoData[DEFAULT_LANGUAGE], layout.margin, layout.y);
+  layout.y += 8;
+};
+
+const drawRows = (doc: JsPdfDocument, layout: PdfLayout, rows: ExportRow[]): void => {
+  if (rows.length === 0) {
+    drawEmptyState(doc, layout);
+    return;
+  }
+
+  const valueX = layout.margin + PDF_LABEL_WIDTH + PDF_ROW_GAP;
+  const valueWidth = layout.contentWidth - PDF_LABEL_WIDTH - PDF_ROW_GAP;
+
+  rows.forEach((row) => {
+    doc.setFontSize(10);
+    doc.setFont('helvetica', 'bold');
+    const labelLines = splitText(doc, row.label, PDF_LABEL_WIDTH);
+    doc.setFont('helvetica', 'normal');
+    const valueLines = splitText(doc, row.value, valueWidth);
+    const lineCount = Math.max(labelLines.length, valueLines.length);
+    const rowHeight = lineCount * PDF_LINE_HEIGHT + PDF_ROW_PADDING * 2;
+
+    ensureSpace(doc, layout, rowHeight);
+
+    const rowTop = layout.y;
+    const textY = rowTop + PDF_ROW_PADDING + 3;
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10);
+    doc.setTextColor(85, 85, 85);
+    doc.text(labelLines, layout.margin, textY);
+
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(29, 29, 27);
+    doc.text(valueLines, valueX, textY);
+
+    layout.y = rowTop + rowHeight;
+    doc.setDrawColor(220, 220, 220);
+    doc.setLineWidth(0.2);
+    doc.line(layout.margin, layout.y, layout.pageWidth - layout.margin, layout.y);
+  });
+
+  layout.y += 7;
+};
+
+const drawFooters = (doc: JsPdfDocument, layout: PdfLayout, generatedAt: string): void => {
+  const pages = doc.getNumberOfPages();
+  const footer = `${Translations.OpportunitySheetGeneratedAt[DEFAULT_LANGUAGE]} ${formatDateTime(generatedAt)}. ${Translations.OpportunitySheetContactsNameOnly[DEFAULT_LANGUAGE]}`;
+  const footerLines = splitText(doc, footer, layout.contentWidth - 22);
+
+  for (let page = 1; page <= pages; page += 1) {
+    doc.setPage(page);
+    doc.setDrawColor(220, 220, 220);
+    doc.setLineWidth(0.2);
+    doc.line(layout.margin, layout.footerY - 6, layout.pageWidth - layout.margin, layout.footerY - 6);
+
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8);
+    doc.setTextColor(120, 120, 120);
+    doc.text(footerLines, layout.margin, layout.footerY - 2);
+    doc.text(`${page}/${pages}`, layout.pageWidth - layout.margin, layout.footerY - 2, { align: 'right' });
+  }
+};
+
+const buildSheetPdf = (doc: JsPdfDocument, params: OpportunitySheetExportParams): JsPdfDocument => {
+  const layout = getLayout(doc);
+  const generatedAt = new Date().toISOString();
+  const summaryRows = buildSummaryRows(params);
+  const attributeRows = buildAttributeRows(params.card, params.schema, params.accounts);
+
+  doc.setProperties({
+    title: `${Translations.OpportunitySheetTitle[DEFAULT_LANGUAGE]} - ${params.card.name}`,
+    subject: Translations.OpportunitySheetTitle[DEFAULT_LANGUAGE],
+  });
+
+  drawTitle(doc, layout, params);
+  drawSectionTitle(doc, layout, Translations.OpportunitySheetSummaryTitle[DEFAULT_LANGUAGE]);
+  drawRows(doc, layout, summaryRows);
+  drawSectionTitle(doc, layout, Translations.OpportunitySheetDetailsTitle[DEFAULT_LANGUAGE]);
+  drawRows(doc, layout, attributeRows);
+  drawFooters(doc, layout, generatedAt);
+
+  return doc;
+};
+
+export const downloadOpportunitySheet = async (params: OpportunitySheetExportParams): Promise<void> => {
+  const { jsPDF } = await import('jspdf');
+  const doc = buildSheetPdf(new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' }), params);
+
+  doc.save(`fiche-opportunite-${fileNamePart(params.card.name)}.pdf`);
+};

--- a/journal/2026-05-10-export-fiche-opportunite.md
+++ b/journal/2026-05-10-export-fiche-opportunite.md
@@ -1,0 +1,28 @@
+# 2026-05-10 — Export de la fiche opportunité
+
+## Contexte
+
+L'issue https://github.com/koden-process/Projet-Unikalo-Meow/issues/127 demande de préparer une fiche opportunité transférable. Le besoin initial mentionnait Outlook, mais la décision produit retenue est de supprimer toute liaison Outlook et de fournir uniquement un téléchargement de la fiche.
+
+## Changement
+
+- Ajout de `frontend/src/helpers/OpportunitySheetExportHelper.ts`.
+- Ajout d'un bouton de téléchargement dans `frontend/src/components/card/Layer.tsx`, visible depuis la fiche d'une opportunité existante.
+- Ajout des libellés d'export dans `frontend/src/Translations.ts`.
+- Ajout de la dépendance frontend `jspdf`.
+- L'export génère un fichier PDF nommé `fiche-opportunite-<nom>.pdf`.
+
+## Décisions implicites
+
+Le PDF est généré côté navigateur avec `jspdf` pour éviter tout changement backend et fournir un téléchargement direct.
+
+La dépendance PDF est chargée dynamiquement au clic afin de ne pas alourdir le chargement initial du board.
+
+Les attributs de référence vers les contacts sont exportés uniquement sous forme de nom. Les coordonnées ou attributs détaillés du contact référencé ne sont pas inclus dans le fichier.
+
+## Impact
+
+- Aucun changement backend.
+- Aucun changement de schéma MongoDB.
+- Aucune intégration Outlook ajoutée.
+- Compatibilité ascendante conservée : l'export s'appuie sur les données déjà chargées dans le store frontend.

--- a/journal/README.md
+++ b/journal/README.md
@@ -75,5 +75,6 @@ Ce qui reste à faire. (Omettre si rien.)
 
 | Date | Titre |
 |---|---|
+| [2026-05-10](2026-05-10-export-fiche-opportunite.md) | Export de la fiche opportunité |
 | [2026-05-10](2026-05-10-script-transfert-opportunites-lanes.md) | Script de transfert des opportunités entre colonnes |
 | [2026-05-09](2026-05-09-init-docs-agent.md) | Mise en place de la documentation agent |


### PR DESCRIPTION
## Contexte

Traite l'issue koden-process/Projet-Unikalo-Meow#127 : permettre de télécharger la fiche opportunité, sans intégration Outlook.

## Changements

- Ajout d’un bouton `Télécharger la fiche PDF` dans la fiche d’une opportunité existante.
- Génération d’un PDF côté frontend avec `jspdf`, chargé dynamiquement au clic.
- Export des contacts référencés uniquement par nom, sans coordonnées ni attributs détaillés.
- Ajout des libellés d’export dans `Translations.ts`.
- Ajout d’une entrée de journal projet pour documenter la décision produit et technique.

## Validation

- `npm run build`
- `git diff --check`
- Vérification dans le navigateur intégré : le bouton `Télécharger la fiche PDF` apparaît dans une fiche opportunité.

Closes koden-process/Projet-Unikalo-Meow#127
