### PR TITLE
[codex] Add manual contact deduplication

### DIFF
--- a/backend/src/controllers/AccountController.ts
+++ b/backend/src/controllers/AccountController.ts
@@ -4,6 +4,7 @@ import { EntityHelper } from '../helpers/EntityHelper.js';
 import { AuthenticatedRequest } from '../requests/AuthenticatedRequest.js';
 import { EventHelper } from '../helpers/EventHelper.js';
 import { validateAndFetchAccount } from '../helpers/EntityFetchHelper.js';
+import { AccountMergeService } from '../services/AccountMergeService.js';
 
 const create = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
@@ -76,9 +77,22 @@ const fetch = async (req: AuthenticatedRequest, res: Response, next: NextFunctio
     }
 };
 
+const merge = async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+        const targetAccount = await validateAndFetchAccount(req.params.id, req.jwt.user);
+        const sourceAccount = await validateAndFetchAccount(req.body.sourceAccountId, req.jwt.user);
+        const result = await AccountMergeService.merge(req.jwt.user, targetAccount, sourceAccount);
+
+        return res.json(result);
+    } catch (error) {
+        return next(error);
+    }
+};
+
 export const AccountController = {
     update,
     create,
     list,
     fetch,
+    merge,
 };

--- a/backend/src/middlewares/schema-validation/AccountMergeRequestSchema.ts
+++ b/backend/src/middlewares/schema-validation/AccountMergeRequestSchema.ts
@@ -1,0 +1,8 @@
+export const AccountMergeRequestSchema = {
+  type: 'object',
+  properties: {
+    sourceAccountId: { type: 'string' },
+  },
+  required: ['sourceAccountId'],
+  additionalProperties: false,
+};

--- a/backend/src/middlewares/schema-validation/AccountsResponseSchema.ts
+++ b/backend/src/middlewares/schema-validation/AccountsResponseSchema.ts
@@ -8,7 +8,19 @@ export const AccountsResponseSchema = {
       name: { type: 'string' },
       status: { type: 'string', enum: ['enabled', 'deleted'] },
       attributes: { type: 'object' },
-      references: { type: ['object', 'null'] },
+      references: {
+        type: ['array', 'null'],
+        items: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            entity: { type: ['string', 'null'] },
+            schemaAttributeKey: { type: 'string' },
+          },
+          required: ['_id', 'schemaAttributeKey'],
+          additionalProperties: false,
+        },
+      },
       createdAt: { type: 'string' },
       updatedAt: { type: 'string' },
     },

--- a/backend/src/services/AccountMergeService.ts
+++ b/backend/src/services/AccountMergeService.ts
@@ -1,0 +1,289 @@
+import { ObjectId } from 'mongodb';
+import { Account, AccountStatus, Reference } from '../entities/Account.js';
+import { NewAccountEvent } from '../entities/AccountEvent.js';
+import { Card } from '../entities/Card.js';
+import { SchemaReferenceAttribute, SchemaType } from '../entities/Schema.js';
+import { User } from '../entities/User.js';
+import { EventType } from '../entities/EventType.js';
+import { InvalidRequestError } from '../errors/InvalidRequestError.js';
+import { DatabaseHelper } from '../helpers/DatabaseHelper.js';
+import { EntityHelper } from '../helpers/EntityHelper.js';
+import { SchemaHelper } from '../helpers/SchemaHelper.js';
+
+export interface AccountMergeSummary {
+  updatedCards: number;
+  updatedAccounts: number;
+  updatedUsers: number;
+  movedAccountEvents: number;
+  targetReferences: number;
+}
+
+export interface AccountMergeResult {
+  targetAccount: Account;
+  sourceAccount: Account;
+  summary: AccountMergeSummary;
+}
+
+const toAccountIdString = (value: unknown): string | null => {
+  if (value instanceof ObjectId) {
+    return value.toString();
+  }
+
+  if (typeof value === 'string' && EntityHelper.isValidEntityId(value)) {
+    return value;
+  }
+
+  return null;
+};
+
+const getAccountReferenceAttributes = async (
+  teamId: ObjectId,
+  type: SchemaType
+): Promise<SchemaReferenceAttribute[]> => {
+  const schema = await EntityHelper.findSchemaByType(teamId, type);
+
+  return SchemaHelper.getSchemaReferenceAttributes(schema?.attributes).filter(
+    (attribute) => attribute.entity === SchemaType.Account
+  );
+};
+
+const replaceReferencesInCollection = async (
+  collectionName: 'Accounts' | 'Cards',
+  teamId: ObjectId,
+  referenceAttributes: SchemaReferenceAttribute[],
+  sourceAccountId: ObjectId,
+  targetAccountId: ObjectId
+): Promise<number> => {
+  const collection = DatabaseHelper.getCollection(collectionName);
+  let updated = 0;
+
+  for (const attribute of referenceAttributes) {
+    const field = `attributes.${attribute.key}`;
+    const result = await collection.updateMany(
+      {
+        teamId,
+        $or: [{ [field]: sourceAccountId.toString() }, { [field]: sourceAccountId }],
+      },
+      {
+        $set: {
+          [field]: targetAccountId.toString(),
+          updatedAt: new Date(),
+        },
+      }
+    );
+
+    updated += result.modifiedCount;
+  }
+
+  return updated;
+};
+
+const replaceFavoriteAccounts = async (
+  teamId: ObjectId,
+  sourceAccountId: ObjectId,
+  targetAccountId: ObjectId
+): Promise<number> => {
+  const usersCollection = DatabaseHelper.getCollection('Users');
+  const users = await usersCollection
+    .find({ teamId, favoriteAccounts: { $exists: true } })
+    .toArray();
+  let updated = 0;
+
+  for (const user of users) {
+    const favoriteAccounts = Array.isArray(user.favoriteAccounts) ? user.favoriteAccounts : [];
+    const next = Array.from(
+      new Map(
+        favoriteAccounts.map((favoriteAccount: ObjectId | string) => {
+          const id = toAccountIdString(favoriteAccount);
+          const nextId = id === sourceAccountId.toString() ? targetAccountId : favoriteAccount;
+
+          return [nextId.toString(), nextId];
+        })
+      ).values()
+    );
+
+    if (
+      next.length !== favoriteAccounts.length ||
+      next.some((favoriteAccount, index) => favoriteAccount.toString() !== favoriteAccounts[index].toString())
+    ) {
+      await usersCollection.updateOne(
+        { _id: user._id },
+        {
+          $set: {
+            favoriteAccounts: next,
+            updatedAt: new Date(),
+          },
+        }
+      );
+      updated += 1;
+    }
+  }
+
+  return updated;
+};
+
+const moveAccountEvents = async (
+  teamId: ObjectId,
+  sourceAccountId: ObjectId,
+  targetAccountId: ObjectId
+): Promise<number> => {
+  const eventsCollection = DatabaseHelper.getCollection('Events');
+  const result = await eventsCollection.updateMany(
+    {
+      teamId,
+      accountId: sourceAccountId,
+    },
+    {
+      $set: {
+        accountId: targetAccountId,
+        updatedAt: new Date(),
+      },
+    }
+  );
+
+  return result.modifiedCount;
+};
+
+const findCardReferencesToAccount = async (
+  teamId: ObjectId,
+  targetAccountId: ObjectId,
+  cardReferenceAttributes: SchemaReferenceAttribute[]
+): Promise<Reference[]> => {
+  if (cardReferenceAttributes.length === 0) {
+    return [];
+  }
+
+  const cardsCollection = DatabaseHelper.getCollection('Cards');
+  const cards = await cardsCollection
+    .find({ teamId })
+    .project<{ _id: ObjectId; attributes?: Card['attributes'] }>({ _id: 1, attributes: 1 })
+    .toArray();
+  const references = new Map<string, Reference>();
+
+  for (const card of cards) {
+    for (const attribute of cardReferenceAttributes) {
+      const value = card.attributes?.[attribute.key];
+
+      if (toAccountIdString(value) !== targetAccountId.toString()) {
+        continue;
+      }
+
+      const key = `${card._id.toString()}:${attribute.key}`;
+      references.set(key, {
+        _id: card._id,
+        entity: attribute.entity,
+        schemaAttributeKey: attribute.key,
+      });
+    }
+  }
+
+  return Array.from(references.values());
+};
+
+const updateReverseReferences = async (
+  teamId: ObjectId,
+  sourceAccountId: ObjectId,
+  targetAccountId: ObjectId,
+  cardReferenceAttributes: SchemaReferenceAttribute[]
+): Promise<number> => {
+  const accountsCollection = DatabaseHelper.getCollection('Accounts');
+  const targetReferences = await findCardReferencesToAccount(
+    teamId,
+    targetAccountId,
+    cardReferenceAttributes
+  );
+
+  await accountsCollection.updateOne(
+    { _id: targetAccountId, teamId },
+    {
+      $set: {
+        references: targetReferences,
+        updatedAt: new Date(),
+      },
+    }
+  );
+
+  await accountsCollection.updateOne(
+    { _id: sourceAccountId, teamId },
+    {
+      $set: {
+        references: [],
+        status: AccountStatus.Deleted,
+        updatedAt: new Date(),
+      },
+    }
+  );
+
+  return targetReferences.length;
+};
+
+const assertMergeIsAllowed = (targetAccount: Account, sourceAccount: Account): void => {
+  if (targetAccount._id.toString() === sourceAccount._id.toString()) {
+    throw new InvalidRequestError('Cannot merge a contact into itself');
+  }
+
+  if (targetAccount.status === AccountStatus.Deleted) {
+    throw new InvalidRequestError('Cannot keep a deleted contact as merge target');
+  }
+
+  if (sourceAccount.status === AccountStatus.Deleted) {
+    throw new InvalidRequestError('Cannot merge a contact that is already deleted');
+  }
+};
+
+const merge = async (
+  user: User,
+  targetAccount: Account,
+  sourceAccount: Account
+): Promise<AccountMergeResult> => {
+  assertMergeIsAllowed(targetAccount, sourceAccount);
+
+  const teamId = user.teamId;
+  const cardReferenceAttributes = await getAccountReferenceAttributes(teamId, SchemaType.Card);
+  const accountReferenceAttributes = await getAccountReferenceAttributes(teamId, SchemaType.Account);
+
+  const updatedCards = await replaceReferencesInCollection(
+    'Cards',
+    teamId,
+    cardReferenceAttributes,
+    sourceAccount._id,
+    targetAccount._id
+  );
+  const updatedAccounts = await replaceReferencesInCollection(
+    'Accounts',
+    teamId,
+    accountReferenceAttributes,
+    sourceAccount._id,
+    targetAccount._id
+  );
+  const updatedUsers = await replaceFavoriteAccounts(teamId, sourceAccount._id, targetAccount._id);
+  const movedAccountEvents = await moveAccountEvents(teamId, sourceAccount._id, targetAccount._id);
+  const targetReferences = await updateReverseReferences(
+    teamId,
+    sourceAccount._id,
+    targetAccount._id,
+    cardReferenceAttributes
+  );
+
+  await EntityHelper.create(
+    new NewAccountEvent(targetAccount, user, EventType.CommentCreated, {
+      text: `Contact fusionné: ${sourceAccount.name}`,
+    })
+  );
+
+  return {
+    targetAccount: await EntityHelper.findOneByIdOrFail(Account, targetAccount._id),
+    sourceAccount: await EntityHelper.findOneByIdOrFail(Account, sourceAccount._id),
+    summary: {
+      updatedCards,
+      updatedAccounts,
+      updatedUsers,
+      movedAccountEvents,
+      targetReferences,
+    },
+  };
+};
+
+export const AccountMergeService = {
+  merge,
+};

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -66,6 +66,7 @@ import { UserUpdateRequestSchema } from './middlewares/schema-validation/UserUpd
 import { PasswordRequestSchema } from './middlewares/schema-validation/PasswordRequestSchema.js';
 import { TeamController } from './controllers/TeamController.js';
 import { AccountRequestSchema } from './middlewares/schema-validation/AccountRequestSchema.js';
+import { AccountMergeRequestSchema } from './middlewares/schema-validation/AccountMergeRequestSchema.js';
 import { EventRequestSchema } from './middlewares/schema-validation/EventRequestSchema.js';
 import { LaneStatisticsController } from './controllers/LaneStatisticsController.js';
 import { EventHelper } from './helpers/EventHelper.js';
@@ -233,6 +234,13 @@ try {
       rejectIfContentTypeIsNot('application/json'),
       validateAgainst(AccountRequestSchema),
       AccountController.update
+    );
+  account
+    .route('/:id/merge')
+    .post(
+      rejectIfContentTypeIsNot('application/json'),
+      validateAgainst(AccountMergeRequestSchema),
+      AccountController.merge
     );
   account.route('/:id').get(AccountController.fetch);
   account.route('/:id/events').get(AccountEventController.list);

--- a/frontend/src/Translations.ts
+++ b/frontend/src/Translations.ts
@@ -67,6 +67,56 @@ export const Translations = {
         fr: 'Contact mis à jour avec succès !',
     },
 
+    AccountDeduplicationButton: {
+        en: 'Deduplicate',
+        fr: 'Dédoublonner',
+    },
+
+    AccountDeduplicationTitle: {
+        en: 'Deduplicate contacts',
+        fr: 'Dédoublonner les contacts',
+    },
+
+    AccountDuplicateCandidatesLabel: {
+        en: 'Likely duplicates',
+        fr: 'Doublons probables',
+    },
+
+    AccountMergeTargetLabel: {
+        en: 'Contact to keep',
+        fr: 'Contact à conserver',
+    },
+
+    AccountMergeSourceLabel: {
+        en: 'Duplicate to merge',
+        fr: 'Doublon à fusionner',
+    },
+
+    AccountMergeImpactNotice: {
+        en: 'Opportunities, linked contacts, favorites and contact history will be reassigned to the kept contact. The duplicate will be marked as deleted.',
+        fr: 'Les opportunités, contacts liés, favoris et historique seront rattachés au contact conservé. Le doublon sera marqué comme supprimé.',
+    },
+
+    AccountMergeInvalidSelection: {
+        en: 'Select two different contacts before merging.',
+        fr: 'Sélectionnez deux contacts différents avant de fusionner.',
+    },
+
+    AccountMergeButton: {
+        en: 'Merge contacts',
+        fr: 'Fusionner les contacts',
+    },
+
+    AccountMergeInProgress: {
+        en: 'Merging...',
+        fr: 'Fusion en cours...',
+    },
+
+    AccountMergeSuccess: {
+        en: '{source} merged into {target}.',
+        fr: '{source} fusionné dans {target}.',
+    },
+
     OpportunityAmount: {
         en: 'Amount',
         fr: 'Quotité',

--- a/frontend/src/components/account/AccountDeduplicationModal.tsx
+++ b/frontend/src/components/account/AccountDeduplicationModal.tsx
@@ -1,0 +1,215 @@
+import {
+  Button,
+  ButtonGroup,
+  ComboBox,
+  Content,
+  Dialog,
+  DialogContainer,
+  Heading,
+  Item,
+} from '@adobe/react-spectrum';
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { ActionType, showModalSuccess } from '../../actions/Actions';
+import { getErrorMessage } from '../../helpers/ErrorHelper';
+import { getRequestClient } from '../../helpers/RequestHelper';
+import { Account } from '../../interfaces/Account';
+import { DEFAULT_LANGUAGE } from '../../Constants';
+import { selectToken, store } from '../../store/Store';
+import { Translations } from '../../Translations';
+
+export interface AccountDeduplicationModalProps {
+  accounts: Account[];
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const normalizeName = (name: string): string => {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+};
+
+const getDuplicateGroups = (accounts: Account[]) => {
+  const groups = new Map<string, Account[]>();
+
+  accounts.forEach((account) => {
+    const key = normalizeName(account.name);
+
+    if (!key) {
+      return;
+    }
+
+    groups.set(key, [...(groups.get(key) ?? []), account]);
+  });
+
+  return Array.from(groups.values())
+    .filter((group) => group.length > 1)
+    .map((group) => group.sort((left, right) => left.name.localeCompare(right.name)));
+};
+
+export const AccountDeduplicationModal = ({
+  accounts,
+  isOpen,
+  onClose,
+}: AccountDeduplicationModalProps) => {
+  const token = useSelector(selectToken);
+  const client = getRequestClient(token);
+  const activeAccounts = useMemo(
+    () =>
+      accounts
+        .filter((account) => account.status !== 'deleted')
+        .slice()
+        .sort((left, right) => left.name.localeCompare(right.name)),
+    [accounts]
+  );
+  const duplicateGroups = useMemo(() => getDuplicateGroups(activeAccounts), [activeAccounts]);
+  const [targetAccountId, setTargetAccountId] = useState('');
+  const [sourceAccountId, setSourceAccountId] = useState('');
+  const [error, setError] = useState('');
+  const [isMerging, setIsMerging] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const firstGroup = duplicateGroups[0];
+    setTargetAccountId(firstGroup?.[0]?._id ?? '');
+    setSourceAccountId(firstGroup?.[1]?._id ?? '');
+    setError('');
+    setIsMerging(false);
+  }, [isOpen, duplicateGroups]);
+
+  const targetAccount = activeAccounts.find((account) => account._id === targetAccountId);
+  const sourceAccount = activeAccounts.find((account) => account._id === sourceAccountId);
+  const canMerge =
+    !!targetAccountId && !!sourceAccountId && targetAccountId !== sourceAccountId && !isMerging;
+
+  const selectDuplicateGroup = (group: Account[]) => {
+    setTargetAccountId(group[0]?._id ?? '');
+    setSourceAccountId(group[1]?._id ?? '');
+    setError('');
+  };
+
+  const merge = async () => {
+    if (!canMerge) {
+      setError(Translations.AccountMergeInvalidSelection[DEFAULT_LANGUAGE]);
+      return;
+    }
+
+    setIsMerging(true);
+    setError('');
+
+    try {
+      await client.mergeAccounts(targetAccountId, sourceAccountId);
+
+      const [updatedAccounts, updatedCards, updatedUsers] = await Promise.all([
+        client.getAccounts(),
+        client.getCards(),
+        client.getUsers(),
+      ]);
+
+      store.dispatch({ type: ActionType.ACCOUNTS, payload: updatedAccounts });
+      store.dispatch({ type: ActionType.CARDS, payload: updatedCards });
+      store.dispatch({ type: ActionType.USERS, payload: updatedUsers });
+      store.dispatch(
+        showModalSuccess(
+          Translations.AccountMergeSuccess[DEFAULT_LANGUAGE]
+            .replace('{source}', sourceAccount?.name ?? '')
+            .replace('{target}', targetAccount?.name ?? '')
+        )
+      );
+      onClose();
+    } catch (error) {
+      setError(await getErrorMessage(error));
+    } finally {
+      setIsMerging(false);
+    }
+  };
+
+  return (
+    <DialogContainer onDismiss={onClose}>
+      {isOpen && (
+        <Dialog>
+          <Heading>{Translations.AccountDeduplicationTitle[DEFAULT_LANGUAGE]}</Heading>
+          <Content>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              {duplicateGroups.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <strong>{Translations.AccountDuplicateCandidatesLabel[DEFAULT_LANGUAGE]}</strong>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {duplicateGroups.slice(0, 5).map((group) => (
+                      <button
+                        key={group.map((account) => account._id).join('-')}
+                        onClick={() => selectDuplicateGroup(group)}
+                        style={{
+                          background: 'transparent',
+                          border: '1px solid #d0d0d0',
+                          borderRadius: 4,
+                          cursor: 'pointer',
+                          padding: '8px 10px',
+                          textAlign: 'left',
+                        }}
+                        type="button"
+                      >
+                        {group.map((account) => account.name).join(' / ')}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <ComboBox
+                aria-label={Translations.AccountMergeTargetLabel[DEFAULT_LANGUAGE]}
+                items={activeAccounts}
+                label={Translations.AccountMergeTargetLabel[DEFAULT_LANGUAGE]}
+                selectedKey={targetAccountId}
+                onSelectionChange={(key) => setTargetAccountId(key ? key.toString() : '')}
+              >
+                {(account: Account) => (
+                  <Item key={account._id} textValue={account.name}>
+                    {account.name}
+                  </Item>
+                )}
+              </ComboBox>
+
+              <ComboBox
+                aria-label={Translations.AccountMergeSourceLabel[DEFAULT_LANGUAGE]}
+                items={activeAccounts}
+                label={Translations.AccountMergeSourceLabel[DEFAULT_LANGUAGE]}
+                selectedKey={sourceAccountId}
+                onSelectionChange={(key) => setSourceAccountId(key ? key.toString() : '')}
+              >
+                {(account: Account) => (
+                  <Item key={account._id} textValue={account.name}>
+                    {account.name}
+                  </Item>
+                )}
+              </ComboBox>
+
+              <div style={{ color: '#555', fontSize: 13 }}>
+                {Translations.AccountMergeImpactNotice[DEFAULT_LANGUAGE]}
+              </div>
+
+              {error && <div style={{ color: '#dc2626', fontSize: 14 }}>{error}</div>}
+            </div>
+          </Content>
+          <ButtonGroup>
+            <Button variant="secondary" onPress={onClose}>
+              {Translations.CancelButton[DEFAULT_LANGUAGE]}
+            </Button>
+            <Button variant="cta" onPress={merge} isDisabled={!canMerge}>
+              {isMerging
+                ? Translations.AccountMergeInProgress[DEFAULT_LANGUAGE]
+                : Translations.AccountMergeButton[DEFAULT_LANGUAGE]}
+            </Button>
+          </ButtonGroup>
+        </Dialog>
+      )}
+    </DialogContainer>
+  );
+};

--- a/frontend/src/helpers/RequestHelper.ts
+++ b/frontend/src/helpers/RequestHelper.ts
@@ -418,6 +418,12 @@ export class RequestHelper {
     return this.doFetch(url, 'POST', body);
   }
 
+  async mergeAccounts(targetAccountId: Account['_id'], sourceAccountId: Account['_id']) {
+    const url = this.getUrl(`/api/accounts/${targetAccountId}/merge`);
+
+    return this.doFetch(url, 'POST', { sourceAccountId });
+  }
+
   async getAccounts(): Promise<Account[]> {
     const url = this.getUrl(`/api/accounts`);
 

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -1,5 +1,5 @@
 import {Button} from '@adobe/react-spectrum';
-import {useEffect, useMemo} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {setListViewColumn, setListViewSortBy, showAccountLayer} from '../actions/Actions';
 import {Layer as AccountLayer} from '../components/account/Layer';
@@ -32,6 +32,7 @@ import {Row} from '../components/view/table/Row';
 import {Layer as CardLayer} from '../components/card/Layer';
 import {Translations} from '../Translations';
 import {DEFAULT_LANGUAGE} from '../Constants';
+import {AccountDeduplicationModal} from '../components/account/AccountDeduplicationModal';
 
 const createListViewItemsFromSchema = (schema: Schema | undefined): ListViewItem[] => {
     const list = [
@@ -73,6 +74,7 @@ export const AccountsPage = () => {
     const token = useSelector(selectToken);
     const sessionUser = useSelector(selectSessionUser);
     const favoriteAccountIds = useSelector(selectFavoriteAccountIds);
+    const [isDeduplicationModalOpen, setIsDeduplicationModalOpen] = useState(false);
 
     const client = getRequestClient(token);
 
@@ -194,11 +196,19 @@ export const AccountsPage = () => {
         <>
             {state === 'account-detail' && <AccountLayer/>}
             {state === 'card-detail' && <CardLayer/>}
+            <AccountDeduplicationModal
+                accounts={accounts}
+                isOpen={isDeduplicationModalOpen}
+                onClose={() => setIsDeduplicationModalOpen(false)}
+            />
 
             <div className="canvas">
                 <div className="list-view-header" style={{display: 'flex', alignItems: 'center'}}>
                     <h2><b>{Translations.DirectoryTitle[DEFAULT_LANGUAGE]}</b> - {rows.length} Contact{rows.length > 1 ? 's' : ''}</h2>
-                    <div style={{marginLeft: 'auto'}}>
+                    <div style={{marginLeft: 'auto', display: 'flex', gap: 8}}>
+                        <Button variant="secondary" onPress={() => setIsDeduplicationModalOpen(true)}>
+                            {Translations.AccountDeduplicationButton[DEFAULT_LANGUAGE]}
+                        </Button>
                         <Button variant="primary" onPress={() => openAccount()}>
                             {Translations.AddButton[DEFAULT_LANGUAGE]}
                         </Button>

--- a/journal/2026-05-10-dedoublonnage-contacts.md
+++ b/journal/2026-05-10-dedoublonnage-contacts.md
@@ -1,0 +1,33 @@
+# 2026-05-10 — Dédoublonnage manuel des contacts
+
+## Contexte
+
+L'issue https://github.com/koden-process/Projet-Unikalo-Meow/issues/117 demande de dédoublonner les contacts. Le dédoublonnage doit rester une action explicite de l'utilisateur, avec un outil de fusion et non une suppression automatique.
+
+## Changement
+
+- Ajout de `backend/src/services/AccountMergeService.ts`.
+- Ajout de `POST /api/accounts/:id/merge`, où `:id` est le contact conservé et `sourceAccountId` le doublon à fusionner.
+- Ajout de `frontend/src/components/account/AccountDeduplicationModal.tsx`.
+- Ajout du bouton `Dédoublonner` sur la page Répertoire.
+- Ajout des libellés frontend dans `frontend/src/Translations.ts`.
+
+## Décisions implicites
+
+La fusion ne mélange pas automatiquement les champs métier du doublon dans le contact conservé. L'utilisateur choisit le contact maître, puis l'outil rattache les chaînes de dépendance au maître.
+
+Les chaînes reprises sont :
+
+- attributs de référence des opportunités vers le contact fusionné ;
+- attributs de référence d'autres contacts vers le contact fusionné ;
+- index inverse `Account.references` utilisé par la fiche contact ;
+- favoris utilisateurs ;
+- historique/commentaires du contact fusionné.
+
+Le doublon est marqué `deleted` au lieu d'être supprimé physiquement.
+
+## Impact
+
+- Nouveau contrat HTTP backend : `POST /api/accounts/:id/merge`.
+- Aucun changement de schéma MongoDB requis.
+- Les clients doivent rafraîchir contacts, opportunités et utilisateurs après fusion pour récupérer les références réécrites.

--- a/journal/README.md
+++ b/journal/README.md
@@ -75,6 +75,7 @@ Ce qui reste à faire. (Omettre si rien.)
 
 | Date | Titre |
 |---|---|
+| [2026-05-10](2026-05-10-dedoublonnage-contacts.md) | Dédoublonnage manuel des contacts |
 | [2026-05-10](2026-05-10-export-fiche-opportunite.md) | Export de la fiche opportunité |
 | [2026-05-10](2026-05-10-script-transfert-opportunites-lanes.md) | Script de transfert des opportunités entre colonnes |
 | [2026-05-09](2026-05-09-init-docs-agent.md) | Mise en place de la documentation agent |


### PR DESCRIPTION
## Summary

- Add a backend merge endpoint for contacts: `POST /api/accounts/:id/merge`.
- Move contact reference chains from the duplicate to the kept contact across opportunity references, contact references, reverse references, favorites, and account events.
- Add a manual deduplication modal on the accounts page so the user chooses the contact to keep and the duplicate to merge.
- Document the implementation decisions in the project journal.

## Impact

The deduplication remains a user-triggered action. The source contact is marked `deleted` instead of being physically removed, and dependent chains are reassigned to the target contact.

Closes koden-process/Projet-Unikalo-Meow#117

## Validation

- `npm run build` in `backend`
- `npm run build` in `frontend`
- `git diff --check`
- Local API check on the merge endpoint with JSON error response for invalid merge selection
