### PR TITLE
fix: secure select and date overlays in constrained spaces

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -58,6 +58,34 @@ h3 {
   min-height: 100vh;
 }
 
+.safe-spectrum-field {
+  display: contents;
+}
+
+.react-spectrum-Popover {
+  z-index: 100000;
+}
+
+.spectrum-Dropdown-popover,
+.spectrum-InputGroup-popover {
+  max-height: min(360px, calc(100vh - 48px));
+}
+
+.spectrum-Dropdown-popover [role="listbox"],
+.spectrum-InputGroup-popover [role="listbox"] {
+  max-height: inherit;
+  overflow-y: auto;
+}
+
+.react-spectrum-Datepicker-dialog {
+  max-height: min(420px, calc(100vh - 48px));
+  overflow: auto;
+}
+
+.react-spectrum-Datepicker-dialogContent {
+  max-height: inherit;
+}
+
 .welcome-page {
   margin: auto;
   max-width: 550px;
@@ -2092,4 +2120,3 @@ body.light [class*="spectrum-Text"] {
 .favorite-btn.is-favorite {
   color: #f5a623;
 }
-

--- a/frontend/src/components/account/AccountDeduplicationModal.tsx
+++ b/frontend/src/components/account/AccountDeduplicationModal.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   ButtonGroup,
-  ComboBox,
   Content,
   Dialog,
   DialogContainer,
@@ -17,6 +16,7 @@ import { Account } from '../../interfaces/Account';
 import { DEFAULT_LANGUAGE } from '../../Constants';
 import { selectToken, store } from '../../store/Store';
 import { Translations } from '../../Translations';
+import { SafeComboBox } from '../common/SafeSpectrumFields';
 
 export interface AccountDeduplicationModalProps {
   accounts: Account[];
@@ -163,7 +163,7 @@ export const AccountDeduplicationModal = ({
                 </div>
               )}
 
-              <ComboBox
+              <SafeComboBox
                 aria-label={Translations.AccountMergeTargetLabel[DEFAULT_LANGUAGE]}
                 items={activeAccounts}
                 label={Translations.AccountMergeTargetLabel[DEFAULT_LANGUAGE]}
@@ -175,9 +175,9 @@ export const AccountDeduplicationModal = ({
                     {account.name}
                   </Item>
                 )}
-              </ComboBox>
+              </SafeComboBox>
 
-              <ComboBox
+              <SafeComboBox
                 aria-label={Translations.AccountMergeSourceLabel[DEFAULT_LANGUAGE]}
                 items={activeAccounts}
                 label={Translations.AccountMergeSourceLabel[DEFAULT_LANGUAGE]}
@@ -189,7 +189,7 @@ export const AccountDeduplicationModal = ({
                     {account.name}
                   </Item>
                 )}
-              </ComboBox>
+              </SafeComboBox>
 
               <div style={{ color: '#555', fontSize: 13 }}>
                 {Translations.AccountMergeImpactNotice[DEFAULT_LANGUAGE]}

--- a/frontend/src/components/card/Form.tsx
+++ b/frontend/src/components/card/Form.tsx
@@ -1,4 +1,4 @@
-import { TextField, DatePicker } from '@adobe/react-spectrum';
+import { TextField } from '@adobe/react-spectrum';
 import { useState, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { parseDate } from '@internationalized/date';
@@ -10,6 +10,7 @@ import { Translations } from '../../Translations';
 import { SchemaCanvas } from '../schema/SchemaCanvas';
 import { Attribute } from '../../interfaces/Attribute';
 import { DEFAULT_LANGUAGE } from '../../Constants';
+import { SafeDatePicker } from '../common/SafeSpectrumFields';
 
 export interface FormProps {
   id: string | undefined;
@@ -154,7 +155,7 @@ export const Form = ({ id, onPreviewChange }: FormProps) => {
 
       <div className="card-dates">
         <div>
-          <DatePicker
+          <SafeDatePicker
             value={
               preview.nextFollowUpAt
                 ? parseDate(preview.nextFollowUpAt.substring(0, 10)) as any
@@ -168,7 +169,7 @@ export const Form = ({ id, onPreviewChange }: FormProps) => {
         </div>
 
         <div>
-          <DatePicker
+          <SafeDatePicker
             value={preview.closedAt ? parseDate(preview.closedAt.substring(0, 10)) as any : undefined}
             onChange={(value) => handlePreviewUpdate('closedAt', value ? value.toString() : '')}
             label={Translations.ExpectedCloseDateLabel[DEFAULT_LANGUAGE]}

--- a/frontend/src/components/card/FormMobile.tsx
+++ b/frontend/src/components/card/FormMobile.tsx
@@ -1,4 +1,4 @@
-import { Button, TextField, DatePicker } from '@adobe/react-spectrum';
+import { Button, TextField } from '@adobe/react-spectrum';
 import { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { parseDate } from '@internationalized/date';
@@ -6,6 +6,7 @@ import { selectUserId } from '../../store/Store';
 import { CardFormPreview } from '../../interfaces/Card';
 import { Translations } from '../../Translations';
 import { DEFAULT_LANGUAGE } from '../../Constants';
+import { SafeDatePicker } from '../common/SafeSpectrumFields';
 import { useNavigate } from 'react-router-dom';
 
 export interface FormMobileProps {
@@ -61,7 +62,7 @@ export const FormMobile = ({ onSubmit }: FormMobileProps) => {
           width="100%"
         />
         <div className="attribute">
-          <DatePicker
+          <SafeDatePicker
             value={
               preview.nextFollowUpAt
                 ? parseDate(preview.nextFollowUpAt.substring(0, 10)) as any

--- a/frontend/src/components/card/TransferModal.tsx
+++ b/frontend/src/components/card/TransferModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Button, TextArea, ComboBox, Item, DialogContainer, Dialog, Heading, Content, ButtonGroup } from '@adobe/react-spectrum';
+import { Button, TextArea, Item, DialogContainer, Dialog, Heading, Content, ButtonGroup } from '@adobe/react-spectrum';
 import { useSelector } from 'react-redux';
 import { selectToken, selectCurrency } from '../../store/Store';
 import { getRequestClient } from '../../helpers/RequestHelper';
@@ -8,6 +8,7 @@ import { Card } from '../../interfaces/Card';
 import { TransferRequest } from '../../interfaces/OpportunityTransfer';
 import { Translations } from '../../Translations';
 import { DEFAULT_LANGUAGE } from '../../Constants';
+import { SafeComboBox } from '../common/SafeSpectrumFields';
 
 export interface TransferModalProps {
   isOpen: boolean;
@@ -106,7 +107,7 @@ export const TransferModal = ({ isOpen, onClose, card, onTransferSuccess }: Tran
                 <strong>{Translations.OpportunityLabel[DEFAULT_LANGUAGE]}</strong> {card.name}
               </div>
 
-              <ComboBox
+              <SafeComboBox
                 aria-label={Translations.TransferToTeamLabel[DEFAULT_LANGUAGE]}
                 items={teams}
                 selectedKey={selectedTeamId}
@@ -118,7 +119,7 @@ export const TransferModal = ({ isOpen, onClose, card, onTransferSuccess }: Tran
                     {team.name}
                   </Item>
                 )}
-              </ComboBox>
+              </SafeComboBox>
 
               <TextArea
                 label={Translations.MessageOptionalLabel[DEFAULT_LANGUAGE]}

--- a/frontend/src/components/common/SafeSpectrumFields.tsx
+++ b/frontend/src/components/common/SafeSpectrumFields.tsx
@@ -1,0 +1,227 @@
+import React, {
+  FocusEvent,
+  KeyboardEvent,
+  PointerEvent,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useRef,
+} from 'react';
+import {
+  ComboBox as SpectrumComboBox,
+  DatePicker as SpectrumDatePicker,
+  DateRangePicker as SpectrumDateRangePicker,
+  Picker as SpectrumPicker,
+} from '@adobe/react-spectrum';
+import type { DateValue, SpectrumDatePickerProps, SpectrumDateRangePickerProps } from '@react-types/datepicker';
+import type { SpectrumComboBoxProps } from '@react-types/combobox';
+import type { SpectrumPickerProps } from '@react-types/select';
+
+const SAFE_PADDING = 24;
+const LIST_MIN_HEIGHT = 280;
+const CALENDAR_MIN_HEIGHT = 360;
+const OPEN_KEYS = new Set(['Enter', ' ', 'ArrowDown']);
+const FIELD_SELECTOR = '.spectrum-Field, .spectrum-Dropdown, .spectrum-InputGroup';
+
+type SafeOverlayKind = 'list' | 'calendar';
+type SafeWrapperProps = {
+  children: ReactNode | ((ensureRootSpace: () => void) => ReactNode);
+  kind: SafeOverlayKind;
+};
+
+const getMinimumOverlayHeight = (kind: SafeOverlayKind) => (
+  kind === 'calendar' ? CALENDAR_MIN_HEIGHT : LIST_MIN_HEIGHT
+);
+
+const getScrollableParent = (element: HTMLElement): HTMLElement | null => {
+  let parent = element.parentElement;
+
+  while (parent && parent !== document.body && parent !== document.documentElement) {
+    const style = window.getComputedStyle(parent);
+    const canScroll = /(auto|scroll|overlay)/.test(style.overflowY);
+
+    if (canScroll && parent.scrollHeight > parent.clientHeight) {
+      return parent;
+    }
+
+    parent = parent.parentElement;
+  }
+
+  return null;
+};
+
+const getFieldElement = (target: EventTarget | null): HTMLElement | null => {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+
+  return target.closest(FIELD_SELECTOR) ?? target;
+};
+
+const getViewportBounds = (container: HTMLElement | null) => {
+  if (container) {
+    return container.getBoundingClientRect();
+  }
+
+  return {
+    top: 0,
+    bottom: window.innerHeight,
+    height: window.innerHeight,
+  };
+};
+
+const scrollBy = (container: HTMLElement | null, top: number) => {
+  if (Math.abs(top) < 1) {
+    return;
+  }
+
+  if (container) {
+    container.scrollBy({ top, behavior: 'auto' });
+    return;
+  }
+
+  window.scrollBy({ top, behavior: 'auto' });
+};
+
+const ensureOverlaySpace = (target: EventTarget | null, kind: SafeOverlayKind) => {
+  const field = getFieldElement(target);
+
+  if (!field) {
+    return;
+  }
+
+  const container = getScrollableParent(field);
+  const bounds = getViewportBounds(container);
+  const rect = field.getBoundingClientRect();
+  const minimumHeight = getMinimumOverlayHeight(kind);
+  const availableAbove = rect.top - bounds.top - SAFE_PADDING;
+  const availableBelow = bounds.bottom - rect.bottom - SAFE_PADDING;
+
+  if (availableAbove >= minimumHeight || availableBelow >= minimumHeight) {
+    return;
+  }
+
+  const fieldCenter = rect.top + rect.height / 2;
+  const boundsCenter = bounds.top + bounds.height / 2;
+  scrollBy(container, fieldCenter - boundsCenter);
+};
+
+const SafeSpectrumField = ({ children, kind }: SafeWrapperProps) => {
+  const rootRef = useRef<HTMLSpanElement>(null);
+
+  const ensureFromEvent = useCallback(
+    (target: EventTarget | null) => ensureOverlaySpace(target, kind),
+    [kind]
+  );
+
+  const handlePointerDownCapture = (event: PointerEvent<HTMLSpanElement>) => {
+    ensureFromEvent(event.target);
+  };
+
+  const handleKeyDownCapture = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (OPEN_KEYS.has(event.key)) {
+      ensureFromEvent(event.target);
+    }
+  };
+
+  const handleFocusCapture = (event: FocusEvent<HTMLSpanElement>) => {
+    ensureFromEvent(event.target);
+  };
+
+  const ensureRootSpace = useCallback(() => {
+    const field = rootRef.current?.querySelector(FIELD_SELECTOR);
+    ensureFromEvent(field ?? rootRef.current);
+  }, [ensureFromEvent]);
+
+  return (
+    <span
+      ref={rootRef}
+      className="safe-spectrum-field"
+      onPointerDownCapture={handlePointerDownCapture}
+      onKeyDownCapture={handleKeyDownCapture}
+      onFocusCapture={handleFocusCapture}
+    >
+      {typeof children === 'function' ? children(ensureRootSpace) : children}
+    </span>
+  );
+};
+
+export const SafePicker = <T extends object>(props: SpectrumPickerProps<T>): ReactElement => {
+  return (
+    <SafeSpectrumField kind="list">
+      {(ensureRootSpace) => (
+        <SpectrumPicker
+          {...props}
+          shouldFlip={props.shouldFlip ?? true}
+          onOpenChange={(isOpen) => {
+            if (isOpen) {
+              ensureRootSpace();
+            }
+
+            props.onOpenChange?.(isOpen);
+          }}
+        />
+      )}
+    </SafeSpectrumField>
+  );
+};
+
+export const SafeComboBox = <T extends object>(props: SpectrumComboBoxProps<T>): ReactElement => {
+  return (
+    <SafeSpectrumField kind="list">
+      {(ensureRootSpace) => (
+        <SpectrumComboBox
+          {...props}
+          shouldFlip={props.shouldFlip ?? true}
+          onOpenChange={(isOpen) => {
+            if (isOpen) {
+              ensureRootSpace();
+            }
+
+            props.onOpenChange?.(isOpen);
+          }}
+        />
+      )}
+    </SafeSpectrumField>
+  );
+};
+
+export const SafeDatePicker = <T extends DateValue>(props: SpectrumDatePickerProps<T>): ReactElement => {
+  return (
+    <SafeSpectrumField kind="calendar">
+      {(ensureRootSpace) => (
+        <SpectrumDatePicker
+          {...props}
+          shouldFlip={props.shouldFlip ?? true}
+          onOpenChange={(isOpen) => {
+            if (isOpen) {
+              ensureRootSpace();
+            }
+
+            props.onOpenChange?.(isOpen);
+          }}
+        />
+      )}
+    </SafeSpectrumField>
+  );
+};
+
+export const SafeDateRangePicker = <T extends DateValue>(props: SpectrumDateRangePickerProps<T>): ReactElement => {
+  return (
+    <SafeSpectrumField kind="calendar">
+      {(ensureRootSpace) => (
+        <SpectrumDateRangePicker
+          {...props}
+          shouldFlip={props.shouldFlip ?? true}
+          onOpenChange={(isOpen) => {
+            if (isOpen) {
+              ensureRootSpace();
+            }
+
+            props.onOpenChange?.(isOpen);
+          }}
+        />
+      )}
+    </SafeSpectrumField>
+  );
+};

--- a/frontend/src/components/forecast/CardList.tsx
+++ b/frontend/src/components/forecast/CardList.tsx
@@ -1,4 +1,4 @@
-import { Item, Picker } from '@adobe/react-spectrum';
+import { Item } from '@adobe/react-spectrum';
 import { useEffect, useMemo, useState } from 'react';
 import { TableHeader } from '../view/table/TableHeader';
 import { ApplicationStore } from '../../store/ApplicationStore';
@@ -25,6 +25,7 @@ import { TableCanvas } from '../view/table/TableCanvas';
 import useMobileLayout from '../../hooks/useMobileLayout';
 import { getRequestClient } from '../../helpers/RequestHelper';
 import { SelectMappingContext } from '../../helpers/SelectMappingContext';
+import { SafePicker } from '../common/SafeSpectrumFields';
 import { useContext } from 'react';
 
 interface CardListProps {
@@ -217,7 +218,7 @@ export const CardList = ({ userId, start, end }: CardListProps) => {
   return (
     <>
       <section className="content-box" style={{ overflow: 'auto' }}>
-        <Picker
+        <SafePicker
           defaultSelectedKey={mode}
           onSelectionChange={(key) => {
             if (key === null) {
@@ -228,7 +229,7 @@ export const CardList = ({ userId, start, end }: CardListProps) => {
         >
           <Item key="achieved">{Translations.ClosedWonOption[DEFAULT_LANGUAGE]}</Item>
           <Item key="predicted">{Translations.AllOpenOption[DEFAULT_LANGUAGE]}</Item>
-        </Picker>
+        </SafePicker>
       </section>
 
       {isMobileLayout ? (

--- a/frontend/src/components/home/FilterBar.tsx
+++ b/frontend/src/components/home/FilterBar.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
-import { Button, Item, Picker, ComboBox } from '@adobe/react-spectrum';
+import { Button, Item } from '@adobe/react-spectrum';
 import { Translations } from '../../Translations';
 import { DEFAULT_LANGUAGE, FILTER_BY_NONE } from '../../Constants';
 import { FilterMode } from '../../pages/HomePage';
 import { User } from '../../interfaces/User';
 import { Account } from '../../interfaces/Account';
+import { SafeComboBox, SafePicker } from '../common/SafeSpectrumFields';
 
 interface FilterBarProps {
     text: string;
@@ -72,7 +73,7 @@ export const FilterBar = ({
                         aria-label={Translations.NameOrStage[DEFAULT_LANGUAGE]}
                         type="text"
                     />
-                    <ComboBox
+                    <SafeComboBox
                         aria-label={hasFavorites ? '★ Contacts favoris' : Translations.FilterByContact[DEFAULT_LANGUAGE]}
                         items={accountFiltered}
                         inputValue={accountSearchText}
@@ -85,8 +86,8 @@ export const FilterBar = ({
                         }}
                     >
                         {(item: Account) => <Item key={item._id} textValue={item.name}>{item.name}</Item>}
-                    </ComboBox>
-                    <Picker
+                    </SafeComboBox>
+                    <SafePicker
                         aria-label={Translations.FilterByUser[DEFAULT_LANGUAGE]}
                         selectedKey={userId}
                         onSelectionChange={(key) => {
@@ -95,7 +96,7 @@ export const FilterBar = ({
                         }}
                     >
                         {getUserOptions()}
-                    </Picker>
+                    </SafePicker>
                     {(selectedAccountId || text || accountSearchText) && (
                         <Button variant="secondary" onPress={onReset}>
                             Réinitialiser

--- a/frontend/src/components/lane/Form.tsx
+++ b/frontend/src/components/lane/Form.tsx
@@ -1,4 +1,4 @@
-import {Button, Checkbox, Item, Picker, TextField} from '@adobe/react-spectrum';
+import {Button, Checkbox, Item, TextField} from '@adobe/react-spectrum';
 import {useState, useMemo, useEffect, Key} from 'react';
 import {useSelector} from 'react-redux';
 import {ActionType} from '../../actions/Actions';
@@ -86,7 +86,7 @@ export const Form = ({id}: FormProps) => {
                     <div style={{paddingTop: '10px'}}>
                         <span
                             style={{lineHeight: '2em'}}>{Translations.HideOpportunitiesMessage[DEFAULT_LANGUAGE]}</span>
-{/*                        <Picker
+{/*                        <SafePicker
                             onSelectionChange={setHideAfterDays}
                             defaultSelectedKey={hideAfterDays.toString()}
                         >
@@ -94,7 +94,7 @@ export const Form = ({id}: FormProps) => {
                             <Item key="30">30</Item>
                             <Item key="60">60</Item>
                             <Item key="90">90</Item>
-                        </Picker>{' '}*/}
+                        </SafePicker>{' '}*/}
                         {Translations.DaysLabel[DEFAULT_LANGUAGE]}
                     </div>
                 ) : null}

--- a/frontend/src/components/schema/ReferenceAttribute.tsx
+++ b/frontend/src/components/schema/ReferenceAttribute.tsx
@@ -1,4 +1,4 @@
-import { Picker, Item } from '@adobe/react-spectrum';
+import { Item } from '@adobe/react-spectrum';
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { selectAccounts } from '../../store/Store';
@@ -6,6 +6,7 @@ import { Account } from '../../interfaces/Account';
 import { Translations } from '../../Translations';
 import { DEFAULT_LANGUAGE } from '../../Constants';
 import { showAccountLayer } from '../../actions/Actions';
+import { SafePicker } from '../common/SafeSpectrumFields';
 
 const getOptions = (accounts: Account[]) => {
   const list: JSX.Element[] = [];
@@ -70,7 +71,7 @@ export const ReferenceAttribute = ({
 
   return (
     <div className="attribute">
-      <Picker
+      <SafePicker
         width="100%"
         aria-label={name}
         label={name}
@@ -79,7 +80,7 @@ export const ReferenceAttribute = ({
         onSelectionChange={(key) => updateValue(key ? key.toString() : '')}
       >
         {getOptions(accounts)}
-      </Picker>
+      </SafePicker>
     </div>
   );
 };

--- a/frontend/src/components/schema/SelectAttribute.tsx
+++ b/frontend/src/components/schema/SelectAttribute.tsx
@@ -1,5 +1,6 @@
-import {Item, Picker} from '@adobe/react-spectrum';
+import {Item} from '@adobe/react-spectrum';
 import {useEffect, useState} from 'react';
+import { SafePicker } from '../common/SafeSpectrumFields';
 
 export interface SelectAttributeProps {
     attributeKey: string;
@@ -32,7 +33,7 @@ export const SelectAttribute = ({
     return (
         <div className="attribute">
             {Array.isArray(options) && (
-                <Picker
+                <SafePicker
                     width="100%"
                     aria-label={name}
                     label={name}
@@ -43,7 +44,7 @@ export const SelectAttribute = ({
                     {options?.sort((a, b) => a.localeCompare(b)).map((option) => {
                         return <Item key={option}>{option}</Item>;
                     })}
-                </Picker>
+                </SafePicker>
             )}
         </div>
     );

--- a/frontend/src/components/setup/currency/CurrencyCanvas.tsx
+++ b/frontend/src/components/setup/currency/CurrencyCanvas.tsx
@@ -1,4 +1,4 @@
-import { Picker, Item } from '@adobe/react-spectrum';
+import { Item } from '@adobe/react-spectrum';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { ActionType, showModalError, showModalSuccess } from '../../../actions/Actions';
@@ -7,6 +7,7 @@ import { selectCurrency, selectTeam, selectToken, store } from '../../../store/S
 import { Translations } from '../../../Translations';
 import { getRequestClient } from '../../../helpers/RequestHelper';
 import { DEFAULT_LANGUAGE } from '../../../Constants'
+import { SafePicker } from '../../common/SafeSpectrumFields';
 
 function parseCurrencyKey(value: React.Key): CurrencyCode {
     switch (value) {
@@ -62,7 +63,7 @@ export const CurrencyCanvas = () => {
     return (
         <div className="content-box">
             <h2>{Translations.CurrencyTitle[DEFAULT_LANGUAGE]}</h2>
-            <Picker
+            <SafePicker
                 selectedKey={currency}
                 aria-label={Translations.CurrencyTitle[DEFAULT_LANGUAGE]}
                 onSelectionChange={(key) => {
@@ -77,7 +78,7 @@ export const CurrencyCanvas = () => {
                 <Item key="SEK">{Translations.SwedishKronaOption[DEFAULT_LANGUAGE]}</Item>
                 <Item key="MT2">{Translations.M2Option[DEFAULT_LANGUAGE]}</Item>
                 <Item key="GBP">{Translations.GBPOption[DEFAULT_LANGUAGE]}</Item>
-            </Picker>
+            </SafePicker>
         </div>
     );
 };

--- a/frontend/src/components/setup/lane/Lane.tsx
+++ b/frontend/src/components/setup/lane/Lane.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Item, Picker, TextField } from '@adobe/react-spectrum';
+import { Checkbox, Item, TextField } from '@adobe/react-spectrum';
 import { useEffect, useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import { LaneListItem } from './LaneSchema';
@@ -6,6 +6,7 @@ import { LaneType, Tags } from '../../../interfaces/Lane';
 import { IconDrag } from '../IconDrag';
 import { Translations } from '../../../Translations';
 import { DEFAULT_LANGUAGE } from '../../../Constants';
+import { SafePicker } from '../../common/SafeSpectrumFields';
 
 export interface LaneProps {
   id: string;
@@ -125,7 +126,7 @@ export const Lane = (props: LaneProps) => {
                 />
               </div>
               <div className="attribute">
-                <Picker
+                <SafePicker
                   aria-label={Translations.LaneTypeLabel[DEFAULT_LANGUAGE]}
                   selectedKey={laneData.type}
                   onSelectionChange={(value) => handleTypeChange(value as LaneType)}
@@ -133,7 +134,7 @@ export const Lane = (props: LaneProps) => {
                   <Item key="normal">{Translations.NormalLaneType[DEFAULT_LANGUAGE]}</Item>
                   <Item key="closed-won">{Translations.ClosedWonLaneType[DEFAULT_LANGUAGE]}</Item>
                   <Item key="closed-lost">{Translations.ClosedLostLaneType[DEFAULT_LANGUAGE]}</Item>
-                </Picker>
+                </SafePicker>
               </div>
               <div className="attribute" style={{ width: '185px' }}>
                 {laneData.type === LaneType.Normal ? (
@@ -149,7 +150,7 @@ export const Lane = (props: LaneProps) => {
               <div className="attribute" style={{ width: '220px' }}>
                 {laneData.type !== LaneType.Normal ? (
                   <>
-                    <Picker
+                    <SafePicker
                       width={100}
                       aria-label={Translations.HideAfterDaysLabel[DEFAULT_LANGUAGE]}
                       onSelectionChange={(value) => updateTags(value ? value.toString() : '')}
@@ -163,7 +164,7 @@ export const Lane = (props: LaneProps) => {
                       <Item key="30">30</Item>
                       <Item key="60">60</Item>
                       <Item key="90">90</Item>
-                    </Picker>
+                    </SafePicker>
                     <span style={{ whiteSpace: 'nowrap', paddingLeft: '10px' }}>
                       {Translations.HideAfterDaysLabel[DEFAULT_LANGUAGE]}
                     </span>

--- a/frontend/src/components/setup/schema/ReferenceAttribute.tsx
+++ b/frontend/src/components/setup/schema/ReferenceAttribute.tsx
@@ -1,4 +1,4 @@
-import {Item, Picker, TextField} from '@adobe/react-spectrum';
+import {Item, TextField} from '@adobe/react-spectrum';
 import {useEffect, useState} from 'react';
 import {Draggable} from 'react-beautiful-dnd';
 import {SchemaReferenceAttribute, SchemaType} from '../../../interfaces/Schema';
@@ -6,6 +6,7 @@ import {IconReverseNameArrow} from '../IconReverseNameArrow';
 import {IconDrag} from '../IconDrag';
 import {Translations} from '../../../Translations';
 import {DEFAULT_LANGUAGE} from '../../../Constants';
+import { SafePicker } from '../../common/SafeSpectrumFields';
 
 export interface ReferenceAttributeProps {
     attributeKey: string;
@@ -51,7 +52,7 @@ export const ReferenceAttribute = ({
                                 <TextField value={name} onChange={setName} onBlur={() => setName(name.trim())}/>
                             </div>
                             <div className="reference">
-                                <Picker
+                                <SafePicker
                                     width="100%"
                                     selectedKey={entity}
                                     onSelectionChange={(key) => {
@@ -67,7 +68,7 @@ export const ReferenceAttribute = ({
                                         .map(([value, key]) => {
                                             return <Item key={key}>{value}</Item>;
                                         })}
-                                </Picker>
+                                </SafePicker>
                             </div>
 
                             <div onClick={() => remove(index)} className="button">

--- a/frontend/src/components/setup/schema/SchemaCanvas.tsx
+++ b/frontend/src/components/setup/schema/SchemaCanvas.tsx
@@ -1,4 +1,4 @@
-import {Button, Item, Picker} from '@adobe/react-spectrum';
+import {Button, Item} from '@adobe/react-spectrum';
 import {Fragment, Key, useEffect, useState} from 'react';
 import {DragDropContext, Droppable, DropResult} from 'react-beautiful-dnd';
 import {ANIMALS, DEFAULT_LANGUAGE} from '../../../Constants';
@@ -19,6 +19,7 @@ import {ReferenceAttribute} from './ReferenceAttribute';
 import {BooleanAttribute} from './BooleanAttribute';
 import {EmailAttribute} from './EmailAttribute';
 import {LinkAttribute} from './LinkAttribute';
+import { SafePicker } from '../../common/SafeSpectrumFields';
 
 function moveAttribute<T>(items: T[], from: number, to: number): T[] {
     const lane = items[from];
@@ -198,7 +199,7 @@ export const SchemaCanvas = ({schema: schemaImported, validate}: SchemaCanvasPro
                 </Droppable>
             </DragDropContext>
             <div className="add-attribute">
-                <Picker
+                <SafePicker
                     defaultSelectedKey="text"
                     onSelectionChange={(key: Key | null) => {
                         if (key === null) return;
@@ -207,7 +208,7 @@ export const SchemaCanvas = ({schema: schemaImported, validate}: SchemaCanvasPro
                 >
 
                     {getOptions(schema)}
-                </Picker>
+                </SafePicker>
 
                 <Button onPress={add} variant="secondary">
                     {Translations.AddAttributeButton[DEFAULT_LANGUAGE]}

--- a/frontend/src/components/setup/user/FormCanvas.tsx
+++ b/frontend/src/components/setup/user/FormCanvas.tsx
@@ -1,4 +1,4 @@
-import {Button, Item, Picker, TextField} from '@adobe/react-spectrum';
+import {Button, Item, TextField} from '@adobe/react-spectrum';
 import {useState} from 'react';
 import {useSelector} from 'react-redux';
 import {ActionType, showModalError, showModalSuccess} from '../../../actions/Actions';
@@ -17,6 +17,7 @@ import {ColorCircleSelected} from './ColorCircleSelected';
 import {ColorCircle} from './ColorCircle';
 import {getRequestClient} from '../../../helpers/RequestHelper';
 import {UserHelper} from '../../../helpers/UserHelper';
+import { SafePicker } from '../../common/SafeSpectrumFields';
 
 
 export const FormCanvas = () => {
@@ -86,7 +87,7 @@ export const FormCanvas = () => {
 
             <div style={{marginBottom: '20px'}}>
                 <div>
-                    <Picker
+                    <SafePicker
                         selectedKey={animal}
                         aria-label={Translations.AnimalLabel[DEFAULT_LANGUAGE]}
                         defaultSelectedKey={animal}
@@ -101,7 +102,7 @@ export const FormCanvas = () => {
                         <Item key="dog">{Translations.DogOption[DEFAULT_LANGUAGE]}</Item>
                         <Item key="bird">{Translations.BirdOption[DEFAULT_LANGUAGE]}</Item>
                         <Item key="no-answer">{Translations.NoAnswerOption[DEFAULT_LANGUAGE]}</Item>
-                    </Picker>
+                    </SafePicker>
                 </div>
                 {animal === 'no-answer' && (
                     <div style={{color: 'red'}}>
@@ -140,7 +141,7 @@ export const FormCanvas = () => {
 
             <h2>{Translations.ThemeLabel[DEFAULT_LANGUAGE]}</h2>
             <div style={{marginBottom: '20px'}}>
-                <Picker
+                <SafePicker
                     selectedKey={theme}
                     aria-label={Translations.ThemeLabel[DEFAULT_LANGUAGE]}
                     onSelectionChange={(key) => {
@@ -151,7 +152,7 @@ export const FormCanvas = () => {
                     <Item key="system">{Translations.ThemeSystemOption[DEFAULT_LANGUAGE]}</Item>
                     <Item key="light">{Translations.ThemeLightOption[DEFAULT_LANGUAGE]}</Item>
                     <Item key="dark">{Translations.ThemeDarkOption[DEFAULT_LANGUAGE]}</Item>
-                </Picker>
+                </SafePicker>
             </div>
 
             <div style={{marginTop: '20px'}}>

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -4,7 +4,7 @@ import { selectInterfaceState, selectToken, store } from '../store/Store';
 import { useEffect, useState } from 'react';
 import { showCardLayer, showModalError } from '../actions/Actions';
 import { getErrorMessage } from '../helpers/ErrorHelper';
-import { Item, Picker } from '@adobe/react-spectrum';
+import { Item } from '@adobe/react-spectrum';
 import { DateTime } from 'luxon';
 import { ActivityItem } from '../components/activity/ActivityItem';
 import { CardEvent } from '../interfaces/CardEvent';
@@ -13,6 +13,7 @@ import { Layer as CardLayer } from '../components/card/Layer';
 import React from 'react';
 import { Translations } from '../Translations';
 import { DEFAULT_LANGUAGE } from '../Constants';
+import { SafePicker } from '../components/common/SafeSpectrumFields';
 
 export const ActivityPage = () => {
   const state = useSelector(selectInterfaceState);
@@ -100,7 +101,7 @@ export const ActivityPage = () => {
     <>
       {state === 'card-detail' && <CardLayer />}
       <div className="canvas">
-        <Picker
+        <SafePicker
           aria-label={Translations.RangeLabel[DEFAULT_LANGUAGE]}
           defaultSelectedKey={range}
           onSelectionChange={(value) => setRange(value ? value.toString() : '')}
@@ -108,7 +109,7 @@ export const ActivityPage = () => {
           <Item key="today">{Translations.TodayOption[DEFAULT_LANGUAGE]}</Item>
           <Item key="week">{Translations.ThisWeekOption[DEFAULT_LANGUAGE]}</Item>
           <Item key="">{Translations.Last90DaysOption[DEFAULT_LANGUAGE]}</Item>
-        </Picker>
+        </SafePicker>
 
         <div className="spinner-canvas">{isLoading ? <div className="spinner"></div> : null}</div>
 

--- a/frontend/src/pages/ForecastPage.tsx
+++ b/frontend/src/pages/ForecastPage.tsx
@@ -1,5 +1,5 @@
 import { today, parseDate, getLocalTimeZone, CalendarDate } from '@internationalized/date';
-import { DateRangePicker, Item, Picker } from '@adobe/react-spectrum';
+import { Item } from '@adobe/react-spectrum';
 import { useEffect, useState } from 'react';
 import { selectActiveUsers, selectDate, selectInterfaceState, store } from '../store/Store';
 import { useSelector } from 'react-redux';
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { TrendView } from '../components/forecast/TrendView';
 import { PipelineView } from '../components/forecast/PipelineView';
 import { Translations } from '../Translations';
+import { SafeDateRangePicker, SafePicker } from '../components/common/SafeSpectrumFields';
 
 const max = today(getLocalTimeZone()).add({
   years: 1,
@@ -98,7 +99,7 @@ export const ForecastPage = () => {
       <div className="forecast">
         <div className="filter">
           <div>
-            <Picker
+            <SafePicker
               width={240}
               label={Translations.ReportLabel[DEFAULT_LANGUAGE]}
               defaultSelectedKey={view}
@@ -110,10 +111,10 @@ export const ForecastPage = () => {
               <Item key="">{Translations.ForecastOption[DEFAULT_LANGUAGE]}</Item>
               <Item key="pipeline-trend">{Translations.SalesPipelineTrendOption[DEFAULT_LANGUAGE]}</Item>
               <Item key="pipeline-generated">{Translations.SalesPipelineGeneratedOption[DEFAULT_LANGUAGE]}</Item>
-            </Picker>
+            </SafePicker>
           </div>
           <div className="users">
-            <Picker
+            <SafePicker
               width={240}
               label={Translations.UserLabel[DEFAULT_LANGUAGE]}
               isDisabled={!userSelect}
@@ -127,11 +128,11 @@ export const ForecastPage = () => {
               {[{ _id: FILTER_BY_NONE.key, name: FILTER_BY_NONE.name }, ...users].map((user) => {
                 return <Item key={user._id}>{user.name}</Item>;
               })}
-            </Picker>
+            </SafePicker>
           </div>
           <div className="spacer"></div>
           <div>
-            <DateRangePicker
+            <SafeDateRangePicker
               label={Translations.CloseDateLabel[DEFAULT_LANGUAGE]}
               aria-label="date"
               value={{

--- a/frontend/src/pages/StatisticPage.tsx
+++ b/frontend/src/pages/StatisticPage.tsx
@@ -5,7 +5,7 @@ import {
   getLocalTimeZone,
   CalendarDate,
 } from '@internationalized/date';
-import { Checkbox, DateRangePicker, Item, Picker } from '@adobe/react-spectrum';
+import { Checkbox, Item } from '@adobe/react-spectrum';
 import { useEffect, useState, useRef } from 'react';
 import { selectActiveUsers, selectLanes, selectToken, store } from '../store/Store';
 import { showModalError } from '../actions/Actions';
@@ -18,6 +18,7 @@ import { FILTER_BY_NONE, DEFAULT_LANGUAGE } from '../Constants';
 import { Chart } from '../components/forecast/Chart';
 import { getRequestClient } from '../helpers/RequestHelper';
 import { Translations } from '../Translations';
+import { SafeDateRangePicker, SafePicker } from '../components/common/SafeSpectrumFields';
 
 const colors = [
   '#e60049',
@@ -208,7 +209,7 @@ export const StatisticPage = () => {
       <div className="forecast">
         <div className="filter">
           <div>
-            <Picker
+            <SafePicker
               defaultSelectedKey={userId}
               onSelectionChange={(key) => {
                 if (key === null) return;
@@ -218,11 +219,11 @@ export const StatisticPage = () => {
               {[{ _id: FILTER_BY_NONE.key, name: FILTER_BY_NONE.name }, ...users].map((user) => {
                 return <Item key={user._id}>{user.name}</Item>;
               })}
-            </Picker>
+            </SafePicker>
           </div>
           <div>
             <b>{Translations.CloseDateLabel[DEFAULT_LANGUAGE]}</b>&nbsp;
-            <DateRangePicker
+            <SafeDateRangePicker
               aria-label="date"
               value={{
                 start: start as any,

--- a/journal/2026-05-12-bug-select-date-overlays.md
+++ b/journal/2026-05-12-bug-select-date-overlays.md
@@ -1,0 +1,23 @@
+# 2026-05-12 — Correction des menus et calendriers en espace contraint
+
+## Contexte
+Des utilisateurs rencontraient un bug dans les fiches opportunité très longues, notamment avec plus de 15 champs configurés et plusieurs listes déroulantes. Les menus de sélection et les calendriers des champs "prochain suivi" et "date de clôture prévue" devenaient difficiles ou impossibles à utiliser lorsqu'ils étaient ouverts près du bas d'une fenêtre ou dans un panneau scrollable.
+
+## Changement
+Ajout de wrappers communs dans `frontend/src/components/common/SafeSpectrumFields.tsx` pour les composants Adobe React Spectrum `Picker`, `ComboBox`, `DatePicker` et `DateRangePicker`.
+
+Ces wrappers recentrent le champ dans son conteneur scrollable avant l'ouverture du menu ou du calendrier, puis conservent le comportement Spectrum existant, notamment le `shouldFlip` par défaut. Les imports directs ont été remplacés dans les écrans et composants concernés.
+
+Des styles globaux ciblés ont été ajoutés dans `frontend/src/App.css` pour limiter la hauteur des popovers et permettre le scroll interne des listes et calendriers.
+
+## Décisions implicites
+Le correctif conserve Adobe React Spectrum et les menus ancrés plutôt que de remplacer les sélecteurs par des modales plein écran. Cette option limite le changement UX tout en traitant le problème de place dans les conteneurs scrollables.
+
+## Impact
+- Frontend uniquement.
+- Aucun changement API ou modèle MongoDB.
+- Aucun changement de configuration ou de dépendance.
+- Les formulaires, filtres, pages forecast/statistiques/setup et modales utilisant des menus Spectrum bénéficient du même comportement.
+
+## Suivi
+Vérifier manuellement une fiche opportunité longue sur desktop et mobile, avec plusieurs listes et les deux champs de date ouverts près du bas de la fenêtre.

--- a/journal/README.md
+++ b/journal/README.md
@@ -75,6 +75,7 @@ Ce qui reste à faire. (Omettre si rien.)
 
 | Date | Titre |
 |---|---|
+| [2026-05-12](2026-05-12-bug-select-date-overlays.md) | Correction des menus et calendriers en espace contraint |
 | [2026-05-10](2026-05-10-dedoublonnage-contacts.md) | Dédoublonnage manuel des contacts |
 | [2026-05-10](2026-05-10-export-fiche-opportunite.md) | Export de la fiche opportunité |
 | [2026-05-10](2026-05-10-script-transfert-opportunites-lanes.md) | Script de transfert des opportunités entre colonnes |


### PR DESCRIPTION
Add safe wrappers around Adobe React Spectrum Picker, ComboBox, DatePicker and DateRangePicker so fields are scrolled into view before opening overlays.

Apply the wrappers across opportunity forms, filters, forecast/statistics/setup screens and recent account/contact modals, and cap popover heights with targeted CSS.

Document the change in the project journal.