### PR TITLE
fix: keep bottom opportunity overlays open

### DIFF
--- a/frontend/src/components/common/SafeSpectrumFields.tsx
+++ b/frontend/src/components/common/SafeSpectrumFields.tsx
@@ -5,7 +5,6 @@ import React, {
   ReactElement,
   ReactNode,
   useCallback,
-  useRef,
 } from 'react';
 import {
   ComboBox as SpectrumComboBox,
@@ -25,7 +24,7 @@ const FIELD_SELECTOR = '.spectrum-Field, .spectrum-Dropdown, .spectrum-InputGrou
 
 type SafeOverlayKind = 'list' | 'calendar';
 type SafeWrapperProps = {
-  children: ReactNode | ((ensureRootSpace: () => void) => ReactNode);
+  children: ReactNode;
   kind: SafeOverlayKind;
 };
 
@@ -107,8 +106,6 @@ const ensureOverlaySpace = (target: EventTarget | null, kind: SafeOverlayKind) =
 };
 
 const SafeSpectrumField = ({ children, kind }: SafeWrapperProps) => {
-  const rootRef = useRef<HTMLSpanElement>(null);
-
   const ensureFromEvent = useCallback(
     (target: EventTarget | null) => ensureOverlaySpace(target, kind),
     [kind]
@@ -128,20 +125,14 @@ const SafeSpectrumField = ({ children, kind }: SafeWrapperProps) => {
     ensureFromEvent(event.target);
   };
 
-  const ensureRootSpace = useCallback(() => {
-    const field = rootRef.current?.querySelector(FIELD_SELECTOR);
-    ensureFromEvent(field ?? rootRef.current);
-  }, [ensureFromEvent]);
-
   return (
     <span
-      ref={rootRef}
       className="safe-spectrum-field"
       onPointerDownCapture={handlePointerDownCapture}
       onKeyDownCapture={handleKeyDownCapture}
       onFocusCapture={handleFocusCapture}
     >
-      {typeof children === 'function' ? children(ensureRootSpace) : children}
+      {children}
     </span>
   );
 };
@@ -149,19 +140,7 @@ const SafeSpectrumField = ({ children, kind }: SafeWrapperProps) => {
 export const SafePicker = <T extends object>(props: SpectrumPickerProps<T>): ReactElement => {
   return (
     <SafeSpectrumField kind="list">
-      {(ensureRootSpace) => (
-        <SpectrumPicker
-          {...props}
-          shouldFlip={props.shouldFlip ?? true}
-          onOpenChange={(isOpen) => {
-            if (isOpen) {
-              ensureRootSpace();
-            }
-
-            props.onOpenChange?.(isOpen);
-          }}
-        />
-      )}
+      <SpectrumPicker {...props} shouldFlip={props.shouldFlip ?? true} />
     </SafeSpectrumField>
   );
 };
@@ -169,19 +148,7 @@ export const SafePicker = <T extends object>(props: SpectrumPickerProps<T>): Rea
 export const SafeComboBox = <T extends object>(props: SpectrumComboBoxProps<T>): ReactElement => {
   return (
     <SafeSpectrumField kind="list">
-      {(ensureRootSpace) => (
-        <SpectrumComboBox
-          {...props}
-          shouldFlip={props.shouldFlip ?? true}
-          onOpenChange={(isOpen) => {
-            if (isOpen) {
-              ensureRootSpace();
-            }
-
-            props.onOpenChange?.(isOpen);
-          }}
-        />
-      )}
+      <SpectrumComboBox {...props} shouldFlip={props.shouldFlip ?? true} />
     </SafeSpectrumField>
   );
 };
@@ -189,19 +156,7 @@ export const SafeComboBox = <T extends object>(props: SpectrumComboBoxProps<T>):
 export const SafeDatePicker = <T extends DateValue>(props: SpectrumDatePickerProps<T>): ReactElement => {
   return (
     <SafeSpectrumField kind="calendar">
-      {(ensureRootSpace) => (
-        <SpectrumDatePicker
-          {...props}
-          shouldFlip={props.shouldFlip ?? true}
-          onOpenChange={(isOpen) => {
-            if (isOpen) {
-              ensureRootSpace();
-            }
-
-            props.onOpenChange?.(isOpen);
-          }}
-        />
-      )}
+      <SpectrumDatePicker {...props} shouldFlip={props.shouldFlip ?? true} />
     </SafeSpectrumField>
   );
 };
@@ -209,19 +164,7 @@ export const SafeDatePicker = <T extends DateValue>(props: SpectrumDatePickerPro
 export const SafeDateRangePicker = <T extends DateValue>(props: SpectrumDateRangePickerProps<T>): ReactElement => {
   return (
     <SafeSpectrumField kind="calendar">
-      {(ensureRootSpace) => (
-        <SpectrumDateRangePicker
-          {...props}
-          shouldFlip={props.shouldFlip ?? true}
-          onOpenChange={(isOpen) => {
-            if (isOpen) {
-              ensureRootSpace();
-            }
-
-            props.onOpenChange?.(isOpen);
-          }}
-        />
-      )}
+      <SpectrumDateRangePicker {...props} shouldFlip={props.shouldFlip ?? true} />
     </SafeSpectrumField>
   );
 };

--- a/journal/2026-05-13-bug-select-overlays-v2.md
+++ b/journal/2026-05-13-bug-select-overlays-v2.md
@@ -1,0 +1,21 @@
+# 2026-05-13 — Correction v2 des menus et calendriers en bas de fiche
+
+## Contexte
+Après la mise en production du correctif des menus et calendriers en espace contraint, les derniers champs d'une fiche opportunité très longue restaient problématiques. Les boutons des derniers `select` et des deux date pickers réagissaient, mais les popups ne s'affichaient pas lorsque l'ascenseur de la fiche était en bas.
+
+## Changement
+Le wrapper `frontend/src/components/common/SafeSpectrumFields.tsx` ne déclenche plus de scroll dans `onOpenChange(true)`.
+
+Le repositionnement du champ reste effectué avant l'ouverture via les événements de capture (`pointerdown`, focus et clavier), mais il n'y a plus de mouvement du conteneur scrollable après l'ouverture déclarée par React Spectrum.
+
+## Décisions implicites
+React Spectrum ferme ses popovers lorsqu'un parent scrollable du déclencheur bouge pendant que la popup est ouverte. Le scroll dans `onOpenChange(true)` pouvait donc ouvrir puis fermer immédiatement la popup, ce qui correspondait au symptôme observé en production.
+
+## Impact
+- Frontend uniquement.
+- Aucun changement API ou modèle MongoDB.
+- Aucun changement de dépendance.
+- Le correctif concerne les champs Spectrum déjà enveloppés par `SafeSpectrumFields`.
+
+## Suivi
+Vérifier en production-like une fiche opportunité longue avec le dernier select et les deux date pickers lorsque l'ascenseur de la fiche est positionné tout en bas.

--- a/journal/README.md
+++ b/journal/README.md
@@ -75,6 +75,7 @@ Ce qui reste à faire. (Omettre si rien.)
 
 | Date | Titre |
 |---|---|
+| [2026-05-13](2026-05-13-bug-select-overlays-v2.md) | Correction v2 des menus et calendriers en bas de fiche |
 | [2026-05-12](2026-05-12-bug-select-date-overlays.md) | Correction des menus et calendriers en espace contraint |
 | [2026-05-10](2026-05-10-dedoublonnage-contacts.md) | Dédoublonnage manuel des contacts |
 | [2026-05-10](2026-05-10-export-fiche-opportunite.md) | Export de la fiche opportunité |


### PR DESCRIPTION
Remove the scroll-on-open behavior from SafeSpectrumFields. React Spectrum closes popovers when a scrollable trigger parent moves while the overlay is open, which made the last select and date pickers react without showing their popup.

Keep pre-open positioning on pointer, focus and keyboard capture so constrained fields are still brought into view before the overlay opens.

Document the production follow-up in the journal.