### PR TITLE
chore(dev): add isolated MongoDB restore workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ yarn-error.log*
 # env vars
 .env
 
+# database backups
+*.archive
+*.archive.gz
+*.bson
+
 # misc
 .rest
 

--- a/backend/scripts/reset-local-user-password.mjs
+++ b/backend/scripts/reset-local-user-password.mjs
@@ -1,0 +1,151 @@
+import { emitKeypressEvents } from 'node:readline';
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+import { hash } from 'bcrypt';
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGODB_URI;
+
+if (!uri) {
+  throw new Error('MONGODB_URI is required.');
+}
+
+const client = new MongoClient(uri);
+
+function readHidden(question) {
+  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
+    throw new Error('A TTY is required to enter the local password securely.');
+  }
+
+  emitKeypressEvents(stdin);
+  stdout.write(question);
+  stdin.setRawMode(true);
+  stdin.resume();
+
+  return new Promise((resolve, reject) => {
+    let value = '';
+
+    const finish = (error) => {
+      stdin.off('keypress', onKeypress);
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdout.write('\n');
+
+      if (error) {
+        reject(error);
+      } else {
+        resolve(value);
+      }
+    };
+
+    const onKeypress = (character, key) => {
+      if (key?.ctrl && key.name === 'c') {
+        finish(new Error('Password entry cancelled.'));
+        return;
+      }
+
+      if (key?.name === 'return' || key?.name === 'enter') {
+        finish();
+        return;
+      }
+
+      if (key?.name === 'backspace') {
+        value = Array.from(value).slice(0, -1).join('');
+        return;
+      }
+
+      if (character && !key?.ctrl && !key?.meta) {
+        value += character;
+      }
+    };
+
+    stdin.on('keypress', onKeypress);
+  });
+}
+
+try {
+  await client.connect();
+  const database = client.db();
+
+  const teamTotals = await database.collection('Cards').aggregate([
+    { $match: { teamId: { $exists: true, $ne: null } } },
+    { $group: { _id: '$teamId', cards: { $sum: 1 } } },
+    { $sort: { cards: -1, _id: 1 } },
+    { $limit: 1 },
+  ]).toArray();
+
+  if (teamTotals.length === 0) {
+    throw new Error('No team with opportunities was found.');
+  }
+
+  const teamId = teamTotals[0]._id;
+  const team = await database.collection('Teams').findOne(
+    { _id: teamId },
+    { projection: { name: 1 } }
+  );
+  const users = await database.collection('Users')
+    .find(
+      { teamId, status: 'enabled' },
+      { projection: { name: 1 } }
+    )
+    .sort({ name: 1, _id: 1 })
+    .toArray();
+
+  if (users.length === 0) {
+    throw new Error('No enabled user was found in the team with the most opportunities.');
+  }
+
+  console.log(
+    `Team with the most opportunities: ${team?.name ?? teamId.toString()} `
+      + `(${teamTotals[0].cards} opportunities)`
+  );
+  users.forEach((user, index) => {
+    console.log(`  ${index + 1}. ${user.name}`);
+  });
+
+  const prompt = createInterface({ input: stdin, output: stdout });
+  const answer = await prompt.question('Select the local login account by number: ');
+  prompt.close();
+  const selectedIndex = Number.parseInt(answer.trim(), 10) - 1;
+
+  if (!Number.isInteger(selectedIndex) || selectedIndex < 0 || selectedIndex >= users.length) {
+    throw new Error('Invalid user selection.');
+  }
+
+  let password;
+  while (true) {
+    password = await readHidden('Local password (minimum 3 characters): ');
+    const confirmation = await readHidden('Confirm local password: ');
+
+    if (password.length < 3) {
+      console.log('Password is too short.');
+      continue;
+    }
+
+    if (password !== confirmation) {
+      console.log('Passwords do not match.');
+      continue;
+    }
+
+    break;
+  }
+
+  const selectedUser = users[selectedIndex];
+  const passwordHash = await hash(password, 10);
+  const result = await database.collection('Users').updateOne(
+    { _id: selectedUser._id, teamId, status: 'enabled' },
+    {
+      $set: {
+        'authentication.local.password': passwordHash,
+      },
+    }
+  );
+
+  if (result.matchedCount !== 1 || result.modifiedCount !== 1) {
+    throw new Error('The selected user could not be updated.');
+  }
+
+  console.log(`Local login ready for: ${selectedUser.name}`);
+} finally {
+  await client.close();
+}

--- a/backend/scripts/restore-local-mongodb-archive.sh
+++ b/backend/scripts/restore-local-mongodb-archive.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CONTAINER_NAME="${MEOW_LOCAL_MONGO_CONTAINER:-meow-local-restore}"
+VOLUME_NAME="${MEOW_LOCAL_MONGO_VOLUME:-meow-local-restore-data}"
+MONGO_IMAGE="${MEOW_LOCAL_MONGO_IMAGE:-mongo:7.0.34}"
+HOST_PORT="${MEOW_LOCAL_MONGO_PORT:-27018}"
+SOURCE_DATABASE="${MEOW_LOCAL_MONGO_SOURCE_DB:-test}"
+TARGET_DATABASE="${MEOW_LOCAL_MONGO_TARGET_DB:-meow_local_restore}"
+MONGODB_URI="mongodb://127.0.0.1:${HOST_PORT}/${TARGET_DATABASE}"
+
+ARCHIVE_PATH=""
+REPLACE=false
+CREATED_RESOURCES=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  restore-local-mongodb-archive.sh --archive /path/to/backup.archive.gz [--replace]
+
+Options:
+  --archive PATH  Gzipped archive produced by mongodump --archive --gzip.
+  --replace       Delete and recreate only the dedicated local container and volume.
+  --help          Show this help.
+
+Optional environment variables:
+  MEOW_LOCAL_MONGO_CONTAINER  Container name (default: meow-local-restore)
+  MEOW_LOCAL_MONGO_VOLUME     Volume name (default: meow-local-restore-data)
+  MEOW_LOCAL_MONGO_IMAGE      MongoDB image (default: mongo:7.0.34)
+  MEOW_LOCAL_MONGO_PORT       Loopback port (default: 27018)
+  MEOW_LOCAL_MONGO_SOURCE_DB  Database name in the archive (default: test)
+  MEOW_LOCAL_MONGO_TARGET_DB  Restored database name (default: meow_local_restore)
+USAGE
+}
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+resource_exists() {
+  docker "$1" inspect "$2" >/dev/null 2>&1
+}
+
+cleanup_on_error() {
+  local status=$?
+  trap - EXIT
+
+  if [[ $status -ne 0 && "$CREATED_RESOURCES" == true ]]; then
+    echo "Restore failed; removing the incomplete dedicated container and volume." >&2
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
+  fi
+
+  exit "$status"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive)
+      [[ $# -ge 2 ]] || fail "--archive requires a path."
+      ARCHIVE_PATH="$2"
+      shift 2
+      ;;
+    --replace)
+      REPLACE=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$ARCHIVE_PATH" ]] || fail "--archive is required."
+[[ -r "$ARCHIVE_PATH" ]] || fail "Archive is not readable: $ARCHIVE_PATH"
+[[ "$HOST_PORT" =~ ^[0-9]+$ ]] || fail "MEOW_LOCAL_MONGO_PORT must be numeric."
+
+command_exists docker || fail "Docker is required."
+command_exists gzip || fail "gzip is required."
+command_exists node || fail "Node.js is required."
+
+docker info >/dev/null 2>&1 || fail "Docker is not running."
+gzip -t "$ARCHIVE_PATH" || fail "The gzip archive is corrupted."
+
+if resource_exists container "$CONTAINER_NAME" || resource_exists volume "$VOLUME_NAME"; then
+  if [[ "$REPLACE" != true ]]; then
+    fail "Dedicated local data already exists. Re-run with --replace to recreate it."
+  fi
+
+  echo "Removing the previous dedicated local restore..."
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  if resource_exists volume "$VOLUME_NAME"; then
+    docker volume rm "$VOLUME_NAME" >/dev/null \
+      || fail "The dedicated volume $VOLUME_NAME could not be removed."
+  fi
+fi
+
+if command_exists lsof && lsof -nP -iTCP:"$HOST_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  fail "Port $HOST_PORT is already in use."
+fi
+
+trap cleanup_on_error EXIT
+
+docker image inspect "$MONGO_IMAGE" >/dev/null 2>&1 || docker pull "$MONGO_IMAGE"
+docker volume create "$VOLUME_NAME" >/dev/null
+CREATED_RESOURCES=true
+
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  --mount "type=volume,source=${VOLUME_NAME},target=/data/db" \
+  --publish "127.0.0.1:${HOST_PORT}:27017" \
+  "$MONGO_IMAGE" >/dev/null
+
+echo "Waiting for MongoDB in $CONTAINER_NAME..."
+ready=false
+for _ in {1..60}; do
+  if docker exec "$CONTAINER_NAME" mongosh --quiet --eval \
+    'quit(db.adminCommand({ ping: 1 }).ok === 1 ? 0 : 1)' >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+[[ "$ready" == true ]] || fail "MongoDB did not become ready within 60 seconds."
+
+restore_arguments=(
+  --uri="mongodb://127.0.0.1:27017/?directConnection=true"
+  --archive
+  --gzip
+  --stopOnError
+  --nsInclude="${SOURCE_DATABASE}.*"
+  --nsExclude="${SOURCE_DATABASE}.restore"
+  --nsFrom="${SOURCE_DATABASE}.*"
+  --nsTo="${TARGET_DATABASE}.*"
+)
+
+echo "Validating archive namespaces with mongorestore --dryRun..."
+docker run --rm \
+  --network "container:${CONTAINER_NAME}" \
+  -i "$MONGO_IMAGE" \
+  mongorestore "${restore_arguments[@]}" --dryRun < "$ARCHIVE_PATH"
+
+echo "Restoring ${SOURCE_DATABASE}.* into ${TARGET_DATABASE}.*..."
+docker run --rm \
+  --network "container:${CONTAINER_NAME}" \
+  -i "$MONGO_IMAGE" \
+  mongorestore "${restore_arguments[@]}" < "$ARCHIVE_PATH"
+
+validation_script='
+const requiredCollections = ["Teams", "Users", "Cards", "Accounts", "Lanes", "Schemas"];
+const availableCollections = db.getCollectionNames();
+const missingCollections = requiredCollections.filter((name) => !availableCollections.includes(name));
+
+if (missingCollections.length > 0) {
+  print(`Missing required collections: ${missingCollections.join(", ")}`);
+  quit(2);
+}
+
+const counts = Object.fromEntries(
+  requiredCollections.map((name) => [name, db.getCollection(name).countDocuments()])
+);
+
+if (counts.Teams === 0 || counts.Users === 0 || counts.Cards === 0) {
+  print(`Required business data is empty: ${JSON.stringify(counts)}`);
+  quit(3);
+}
+
+function countOrphans(collection, localField, foreignCollection, additionalMatch = {}) {
+  const result = db.getCollection(collection).aggregate([
+    {
+      $match: {
+        ...additionalMatch,
+        [localField]: { $exists: true, $ne: null }
+      }
+    },
+    {
+      $lookup: {
+        from: foreignCollection,
+        localField,
+        foreignField: "_id",
+        as: "_matches"
+      }
+    },
+    { $match: { "_matches.0": { $exists: false } } },
+    { $count: "count" }
+  ]).toArray();
+
+  return result.length === 0 ? 0 : result[0].count;
+}
+
+const orphans = {
+  cardTeams: countOrphans("Cards", "teamId", "Teams"),
+  cardUsers: countOrphans("Cards", "userId", "Users"),
+  cardLanes: countOrphans("Cards", "laneId", "Lanes"),
+  activeCardUsers: countOrphans(
+    "Cards",
+    "userId",
+    "Users",
+    { status: { $ne: "deleted" } }
+  ),
+  activeCardLanes: countOrphans(
+    "Cards",
+    "laneId",
+    "Lanes",
+    { status: { $ne: "deleted" } }
+  ),
+  userTeams: countOrphans("Users", "teamId", "Teams"),
+  accountTeams: countOrphans("Accounts", "teamId", "Teams"),
+  laneTeams: countOrphans("Lanes", "teamId", "Teams"),
+  schemaTeams: countOrphans("Schemas", "teamId", "Teams")
+};
+
+print(JSON.stringify({ counts, orphans }, null, 2));
+
+const blockingOrphans = {
+  cardTeams: orphans.cardTeams,
+  userTeams: orphans.userTeams,
+  accountTeams: orphans.accountTeams,
+  laneTeams: orphans.laneTeams,
+  schemaTeams: orphans.schemaTeams
+};
+
+if (Object.values(blockingOrphans).some((count) => count !== 0)) {
+  quit(4);
+}
+
+if (orphans.cardUsers !== 0 || orphans.cardLanes !== 0) {
+  print(
+    "Warning: the source backup contains opportunity references to missing "
+      + "users or lanes. They are preserved unchanged in this faithful local copy."
+  );
+}
+'
+
+echo "Checking restored collections and primary references..."
+docker exec "$CONTAINER_NAME" \
+  mongosh --quiet "$TARGET_DATABASE" --eval "$validation_script"
+
+# The database is complete and validated. Authentication setup errors must not
+# delete the restored copy, so destructive cleanup stops here.
+trap - EXIT
+
+echo
+echo "Select the local login account and set a local-only password."
+MONGODB_URI="$MONGODB_URI" node "$SCRIPT_DIR/reset-local-user-password.mjs"
+
+echo
+echo "Local restore is ready."
+echo "MongoDB URI: $MONGODB_URI"
+echo
+echo "Backend:"
+echo "  export MONGODB_URI='$MONGODB_URI'"
+echo "  export SESSION_SECRET='local-dev-secret'"
+echo "  cd backend && npm start"
+echo
+echo "Frontend:"
+echo "  export VITE_URL='http://127.0.0.1:9000'"
+echo "  unset VITE_CUSTOM_OPPORTUNITY_PDF_TEMPLATE_URL"
+echo "  cd frontend && npm start -- --host 127.0.0.1"

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -26,6 +26,69 @@ mongorestore --uri="<mongodb-uri>" backup-meow
 
 Tester les restaurations sur un environnement non production.
 
+### Restauration locale isolée d'une archive
+
+Le script `backend/scripts/restore-local-mongodb-archive.sh` restaure une archive
+`mongodump --archive --gzip` dans un conteneur dédié. Il ne réutilise ni le
+MongoDB de Docker Compose ni une autre base locale.
+
+```bash
+./backend/scripts/restore-local-mongodb-archive.sh \
+  --archive /chemin/vers/sauvegarde.archive.gz
+```
+
+Par défaut, le script :
+
+- lance `mongo:7.0.34` dans `meow-local-restore` ;
+- publie MongoDB uniquement sur `127.0.0.1:27018` ;
+- conserve les données dans le volume `meow-local-restore-data` ;
+- restaure `test.*` vers `meow_local_restore.*` ;
+- ignore les collections `admin.*` et la collection technique `test.restore` ;
+- contrôle les collections principales et leurs références structurelles ;
+- signale sans les corriger les références historiques d'opportunités vers des
+  utilisateurs ou étapes absents de la sauvegarde ;
+- demande quel compte actif utiliser puis remplace uniquement son mot de passe
+  dans la copie locale.
+
+Si une restauration existe déjà, le script s'arrête. Pour recréer exclusivement
+ce conteneur et ce volume dédiés :
+
+```bash
+./backend/scripts/restore-local-mongodb-archive.sh \
+  --archive /chemin/vers/nouvelle-sauvegarde.archive.gz \
+  --replace
+```
+
+La sauvegarde et les mots de passe ne doivent jamais être copiés dans le dépôt.
+Les extensions `.archive`, `.archive.gz` et `.bson` sont ignorées par Git.
+
+Pour démarrer Meow sur la copie restaurée :
+
+```bash
+cd backend
+export MONGODB_URI=mongodb://127.0.0.1:27018/meow_local_restore
+export SESSION_SECRET=local-dev-secret
+npm start
+```
+
+Dans un second terminal :
+
+```bash
+cd frontend
+export VITE_URL=http://127.0.0.1:9000
+unset VITE_CUSTOM_OPPORTUNITY_PDF_TEMPLATE_URL
+npm start -- --host 127.0.0.1
+```
+
+Le frontend est alors accessible sur `http://127.0.0.1:3119`.
+
+Pour arrêter et supprimer la copie locale :
+
+```bash
+docker rm -f meow-local-restore
+docker volume rm meow-local-restore-data
+```
+
 ## Dépendances
 
 Le projet possède deux arbres npm :
@@ -43,4 +106,3 @@ La documentation doit évoluer avec le code :
 - Variable ajoutée : mettre à jour [Variables d'environnement](../getting-started/environment-variables.md).
 - Workflow modifié : mettre à jour [Workflows système](../architecture/workflows.md).
 - Déploiement modifié : mettre à jour [Déploiement](../infrastructure/deployment.md).
-

--- a/journal/2026-06-30-restauration-mongodb-locale.md
+++ b/journal/2026-06-30-restauration-mongodb-locale.md
@@ -1,0 +1,44 @@
+# 2026-06-30 — Restauration MongoDB locale isolée
+
+## Contexte
+
+Les sauvegardes de données réelles doivent pouvoir être testées localement sans
+écraser les bases de développement existantes, restaurer les utilisateurs
+administrateurs MongoDB ou exposer les données sur le réseau.
+
+## Changement
+
+- Ajout d'un script générique de restauration des archives
+  `mongodump --archive --gzip`.
+- Utilisation d'un conteneur et d'un volume Docker dédiés, exposés uniquement sur
+  `127.0.0.1:27018`.
+- Restauration paramétrable d'une base source vers `meow_local_restore`, sans les
+  collections `admin` ni la collection technique `restore`.
+- Validation des collections principales et des références entre opportunités,
+  équipes, utilisateurs, comptes, étapes et schémas.
+- Ajout d'un helper interactif qui remplace uniquement le hash du mot de passe
+  d'un utilisateur actif dans la copie locale.
+- Ajout des formats de sauvegarde MongoDB aux exclusions Git.
+
+## Décisions implicites
+
+L'image MongoDB par défaut est `mongo:7.0.34` afin de correspondre à la version
+de la sauvegarde ayant motivé l'outillage. Elle reste configurable par variable
+d'environnement pour de futures archives.
+
+Le script refuse tout remplacement implicite. L'option `--replace` ne supprime
+que le conteneur `meow-local-restore` et le volume
+`meow-local-restore-data`.
+
+Les références structurelles orphelines vers une équipe font échouer la
+restauration. Les références d'opportunités vers des utilisateurs ou étapes
+absents sont signalées mais conservées : les réparer automatiquement modifierait
+la copie source et masquerait une dette de qualité des données.
+
+## Impact
+
+- Aucun changement de schéma ou d'API Meow.
+- Aucun secret ni fichier de sauvegarde versionné.
+- Les MongoDB existants et les ports `27017` et `5971` ne sont pas modifiés.
+- Les tests d'intégration backend ne doivent pas être lancés sur une copie de
+  données client, car ils créent des données persistantes.

--- a/journal/README.md
+++ b/journal/README.md
@@ -75,6 +75,7 @@ Ce qui reste à faire. (Omettre si rien.)
 
 | Date | Titre |
 |---|---|
+| [2026-06-30](2026-06-30-restauration-mongodb-locale.md) | Restauration MongoDB locale isolée |
 | [2026-05-29](2026-05-29-affichage-fiche-opportunite-routes.md) | Stabilisation de la fiche opportunité entre pages |
 | [2026-05-29](2026-05-29-bug-select-bas-de-fiche-v3.md) | Correction v3 des menus en bas de fiche opportunité |
 | [2026-05-29](2026-05-29-refonte-documentation.md) | Refonte de la documentation projet |


### PR DESCRIPTION
## Pourquoi

Permettre de restaurer une sauvegarde client en local sans toucher aux MongoDB
existants, sans versionner l'archive ni introduire de données ou de secrets
client dans le dépôt.

## Changements

- ajoute `backend/scripts/restore-local-mongodb-archive.sh` pour valider puis
  restaurer une archive `mongodump --archive --gzip` ;
- utilise un conteneur `mongo:7.0.34`, un volume et le port loopback
  `127.0.0.1:27018` dédiés ;
- restaure uniquement `test.*` vers `meow_local_restore.*`, en excluant
  `test.restore` et toutes les collections `admin.*` ;
- refuse tout écrasement implicite et limite `--replace` aux ressources
  `meow-local-restore` ;
- contrôle les collections requises, leurs volumes et les références
  structurelles principales ;
- ajoute un helper Node interactif qui sélectionne un utilisateur actif de
  l'équipe ayant le plus d'affaires, demande deux fois un mot de passe masqué et
  modifie uniquement `authentication.local.password` ;
- documente la restauration, le remplacement, le démarrage et la suppression ;
- ignore les formats d'archives MongoDB dans Git.

## Validation

- `bash -n backend/scripts/restore-local-mongodb-archive.sh`
- `node --check backend/scripts/reset-local-user-password.mjs`
- `npm run build` dans `backend`
- `npm run build` dans `frontend`
- `git diff --check`
- dry-run `mongorestore` puis restauration réelle : 8 461 documents, dont 642
  affaires, 488 comptes, 39 utilisateurs, 20 étapes et 6 schémas
- garde-fou vérifié : une seconde restauration sans `--replace` est refusée
  sans altérer la base
- connexion backend, authentification locale et affichage frontend vérifiés ;
  l'API et l'interface exposent 576 affaires visibles

Aucun test d'intégration destructif n'a été exécuté sur cette copie.

## Qualité des données source

La sauvegarde contient 22 références d'affaires vers des utilisateurs absents et
48 vers des étapes absentes (respectivement 4 et 30 sur les affaires non
supprimées). Elles sont signalées, mais conservées afin de ne pas modifier
silencieusement la copie client. Les références structurelles vers les équipes
restent bloquantes.

## Impact

Aucun changement de schéma applicatif, d'API ou de comportement en production.
L'archive et le mot de passe local ne sont jamais écrits dans le dépôt.
